### PR TITLE
Ensure UI fields refresh templates

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -316,6 +316,7 @@ class MainWindow(QMainWindow):
             }
             w['computo_tipo'].addItems(["Efec.", "Cond."])
             w['servicio_penitenciario'].addItems(PENITENCIARIOS)
+            w['dni'].textChanged.connect(self.update_templates)
             w['computo'].textChanged.connect(self.update_templates)
             w['computo_tipo'].currentIndexChanged.connect(self.update_templates)
             w['condena'].textChanged.connect(self.update_templates)
@@ -366,6 +367,7 @@ class MainWindow(QMainWindow):
         self.selector_imp.blockSignals(False)
         self.selector_imp.setCurrentIndex(0)
         self._refresh_imp_names_in_selector()
+        self.update_templates()
 
 
     def _refresh_imp_names_in_selector(self):
@@ -454,6 +456,7 @@ class MainWindow(QMainWindow):
                     elif isinstance(widget, QComboBox):
                         widget.setCurrentText(v)
             self._refresh_imp_names_in_selector()
+            self.update_templates()
         except Exception as e:
             QMessageBox.critical(self, "Error", str(e))
 


### PR DESCRIPTION
## Summary
- trigger template updates when changing DNI
- refresh template area when rebuilding defendant tabs
- update templates right after loading a saved case

## Testing
- `python -m py_compile ospro.py`


------
https://chatgpt.com/codex/tasks/task_b_6888d5865ca88322b701a43de4bb3e03