### PR TITLE
Add dynamic related tab reveal with fade effect

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -13,7 +13,8 @@ from PySide6.QtWidgets import (
     QScrollArea, QSizePolicy, QSplitter, QTextEdit     
 )
 from PySide6.QtGui import QIcon, QTextCursor, QFont   # QIcon y QFont para más adelante
-from PySide6.QtWidgets import QHBoxLayout, QStyle
+from PySide6.QtWidgets import QHBoxLayout, QGraphicsOpacityEffect, QStyle
+from PySide6.QtCore import QPropertyAnimation
 from PySide6.QtGui import QTextBlockFormat, QTextCharFormat
 # ── NUEVOS IMPORTS ──────────────────────────────────────────────
 import openai                    # cliente oficial
@@ -292,13 +293,25 @@ class MainWindow(QMainWindow):
             self.tab_indices[name] = idx
             self.text_edits[name] = te
 
+        self.tab_widgets = {n: self.tabs_txt.widget(i) for n, i in self.tab_indices.items()}
+        self.related_pairs = [
+            ("Oficio Registro Automotor", "Oficio TSJ Sec. Penal"),
+            ("Oficio TSJ Sec. Penal (Depósitos)", "Oficio Comisaría Traslado"),
+        ]
+        self.hidden_tabs = {}
+        for _, second in self.related_pairs:
+            w = self.tab_widgets[second]
+            idx = self.tabs_txt.indexOf(w)
+            self.tabs_txt.removeTab(idx)
+            self.hidden_tabs[second] = w
+
+        self.tabs_txt.currentChanged.connect(self._check_related_tabs)
+
         bar = self.tabs_txt.tabBar()
         icon_next = self.style().standardIcon(QStyle.SP_ArrowRight)
         icon_prev = self.style().standardIcon(QStyle.SP_ArrowLeft)
-        bar.setTabIcon(self.tab_indices["Oficio Registro Automotor"], icon_prev)
-        bar.setTabIcon(self.tab_indices["Oficio TSJ Sec. Penal"], icon_next)
-        bar.setTabIcon(self.tab_indices["Oficio TSJ Sec. Penal (Depósitos)"], icon_prev)
-        bar.setTabIcon(self.tab_indices["Oficio Comisaría Traslado"], icon_next)
+        bar.setTabIcon(self.tabs_txt.indexOf(self.tab_widgets["Oficio Registro Automotor"]), icon_prev)
+        bar.setTabIcon(self.tabs_txt.indexOf(self.tab_widgets["Oficio TSJ Sec. Penal (Depósitos)"]), icon_prev)
 
         # ─── AHORA que selector_imp existe, construimos imputados ───
         self.imputados_widgets = []         #  ← línea movida aquí
@@ -306,6 +319,23 @@ class MainWindow(QMainWindow):
 
         # primer refresco de textos
         self.update_templates()
+
+    def _check_related_tabs(self, idx: int) -> None:
+        name = self.tabs_txt.tabText(idx)
+        for first, second in self.related_pairs:
+            if name == first and second in self.hidden_tabs:
+                widget = self.hidden_tabs.pop(second)
+                idx_first = self.tabs_txt.indexOf(self.tab_widgets[first])
+                self.tabs_txt.insertTab(idx_first + 1, widget, second)
+                widget.setStyleSheet("background-color: lightgray;")
+                effect = QGraphicsOpacityEffect(widget)
+                widget.setGraphicsEffect(effect)
+                anim = QPropertyAnimation(effect, b"opacity", self)
+                anim.setDuration(300)
+                anim.setStartValue(0)
+                anim.setEndValue(1)
+                anim.start(QPropertyAnimation.DeleteWhenStopped)
+                break
 
     def rebuild_imputados(self):
         """Reconstruye las pestañas según la cantidad elegida, sin perder datos."""


### PR DESCRIPTION
## Summary
- import `QGraphicsOpacityEffect` and `QPropertyAnimation`
- track tab widgets and related tab pairs
- hide related tabs until their counterparts are selected
- fade in the revealed tab when shown
- adjust tab icon setup

## Testing
- `python -m py_compile ospro.py`

------
https://chatgpt.com/codex/tasks/task_b_6888e730c94483229cf0f4eadf1def33