### PR TITLE
Fix duplicate related_pairs

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -279,6 +279,8 @@ class MainWindow(QMainWindow):
             "#related_indicator{background:palette(highlight);height:2px;border-radius:1px;}"
         )
         self.related_indicator.hide()
+        # Pares de pestañas cuyo vínculo se destaca con una animación
+        # cuando el usuario cambia u observa las tabs.
         self.related_pairs = [
             ("Oficio Registro Automotor", "Oficio TSJ Sec. Penal"),
             ("Oficio TSJ Sec. Penal (Depósitos)", "Oficio Comisaría Traslado"),
@@ -331,12 +333,6 @@ class MainWindow(QMainWindow):
             self.text_edits[name] = te
 
         self.tab_widgets = {n: self.tabs_txt.widget(i) for n, i in self.tab_indices.items()}
-        # Pares de pestañas cuyo vínculo se destaca con una animación
-        # cuando el usuario cambia u observa las tabs.
-        self.related_pairs = [
-            ("Oficio Registro Automotor", "Oficio TSJ Sec. Penal"),
-            ("Oficio TSJ Sec. Penal (Depósitos)", "Oficio Comisaría Traslado"),
-        ]
 
         # ─── AHORA que selector_imp existe, construimos imputados ───
         self.imputados_widgets = []         #  ← línea movida aquí


### PR DESCRIPTION
## Summary
- ensure `related_pairs` is only defined once in `__init__`
- keep explanation comment and remove redundant definition

## Testing
- `python -m py_compile ospro.py`

------
https://chatgpt.com/codex/tasks/task_b_6889f95b45b48322b47a2fbbf4408257