### PR TITLE
Fix regex and ensure final resuelvo block

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -162,7 +162,7 @@ _RESUELVO_REGEX = re.compile(
         (                               # ── INICIO bloque a devolver ──
             (?:                         #   uno o más ítems “I) …”
                 \s*[IVXLCDM]+\)\s.*?    #   línea con número romano
-                (?:\n(?!\s*[IVXLCDM]+\)).*?  #   líneas internas que NO
+                (?:\n(?!\s*[IVXLCDM]+\)).*?)*  #   líneas internas que NO
             )+                          #   comienzan con otro número
         )                               # ── FIN bloque ──
         (?=                             # look‑ahead de cierre
@@ -829,8 +829,8 @@ class MainWindow(QMainWindow):
             # --------------- asegurar que 'resuelvo' tenga contenido ---------------
 # --------------- asegurar que 'resuelvo' tenga buen contenido ---------------
             g = datos.get("generales", {})
-            if not g.get("resuelvo"):                # si vino vacío...
-                g["resuelvo"] = extraer_resuelvo(texto)  # ...lo rellenamos nosotros
+            # siempre priorizamos el bloque final de la sentencia
+            g["resuelvo"] = extraer_resuelvo(texto)
 
             # normalizar saltos de línea (opcional pero recomendable)
             g["resuelvo"] = re.sub(r"\s*\n\s*", " ", g["resuelvo"]).strip()


### PR DESCRIPTION
## Summary
- correct `_RESUELVO_REGEX` capturing group
- always extract the final `resuelvo` block from the sentence

## Testing
- `python3 -m py_compile ospro.py`
- `python3 - <<'PY'
import re
pattern = r'''(?isx)
        (
            (?:
                \s*[IVXLCDM]+\)\s.*?
                (?:\n(?!\s*[IVXLCDM]+\)).*?)*
            )+
        )
        (?=
            \s*(?:Protocol[íi]?cese
               |Notifíquese
               |Hágase\s+saber
               |Of[íi]ciese)
        )
    '''
re.compile(pattern, re.IGNORECASE|re.DOTALL|re.VERBOSE)
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_b_688a3ddf06408322ad617c6651ea91c6