### PR TITLE
Fix regex for sentence closing parsing

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -161,7 +161,7 @@ def html_a_plano(html: str, mantener_saltos: bool = True) -> str:
 # y finalizada con las fórmulas de cierre habituales.
 _RESUELVO_REGEX = re.compile(
     r'''(?isx)
-        resuelv[ao]\s*:?                 # palabra clave introductoria
+        resuelv[eo]\s*:?                 # palabra clave introductoria
         (                                 # ── INICIO bloque a devolver ──
             (?:                           #   uno o más ítems "I) …"
                 \s*[IVXLCDM]+\)\s.*?     #   línea con número romano


### PR DESCRIPTION
## Summary
- correct `_RESUELVO_REGEX` to match "RESUELVE" or "RESUELVO" endings

## Testing
- `python3 -m py_compile ospro.py`

------
https://chatgpt.com/codex/tasks/task_b_688a46a360208322ad1a0342cd95e3cb