### PR TITLE
Add anchor editing system

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,23 @@
+import html
+
+
+def anchor(texto: str, clave: str, placeholder: str = None) -> str:
+    """Devuelve un enlace HTML plano"""
+    if not texto.strip():
+        texto = placeholder or f"[{clave}]"
+    return (
+        f'<a href="{clave}" ' \
+        'style="color:blue;text-decoration:none;">' \
+        f"{html.escape(texto)}</a>"
+    )
+
+
+def anchor_html(html_text: str, clave: str, placeholder: str = None) -> str:
+    """Igual que anchor pero conserva etiquetas básicas"""
+    if not html_text.strip():
+        return anchor("", clave, placeholder)
+    return (
+        f'<a href="{clave}" ' \
+        'style="color:blue;text-decoration:none;">' \
+        f"{html_text}</a>"
+    )


### PR DESCRIPTION
## Summary
- implement `anchor` and `anchor_html` utility functions
- switch QTextEdits to QTextBrowser and connect `anchorClicked`
- add helpers for editing fields via anchors
- add anchor versions of some templates

## Testing
- `python -m py_compile ospro.py helpers.py`

------
https://chatgpt.com/codex/tasks/task_b_688a60f98eb48322b0ec616a346a7424