### PR TITLE
Restrict Times New Roman to oficio text

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -1852,7 +1852,6 @@ class MainWindow(QMainWindow):
 # ──────────────────────────── main ───────────────────────────────
 def main():
     app = QApplication(sys.argv)
-    app.setFont(QFont("Times New Roman", 12))
 
     # ahora SÍ podés usar QMessageBox
     if not os.getenv("OPENAI_API_KEY"):


### PR DESCRIPTION
## Summary
- remove application-wide font override so Times New Roman 12 applies only to the oficio tabs

## Testing
- `python -m py_compile ospro.py`


------
https://chatgpt.com/codex/tasks/task_b_688a7e2f9fac8322b5d0fce5aa489b5e