### PR TITLE
Improve combo box anchor editing

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -1774,7 +1774,16 @@ class MainWindow(QMainWindow):
             self.update_templates()
 
     def _editar_combo(self, widget: QComboBox, titulo: str):
-        texto, ok = QInputDialog.getText(self, titulo, titulo, text=widget.currentText())
+        items = [widget.itemText(i) for i in range(widget.count())]
+        idx = widget.currentIndex()
+        texto, ok = QInputDialog.getItem(
+            self,
+            titulo,
+            titulo,
+            items,
+            idx,
+            editable=widget.isEditable(),
+        )
         if ok:
             widget.setCurrentText(texto.strip())
             self.update_templates()


### PR DESCRIPTION
## Summary
- when clicking anchors linked to combo boxes, show an editable combobox dialog instead of a text entry

## Testing
- `python -m py_compile ospro.py helpers.py`

------
https://chatgpt.com/codex/tasks/task_b_688b4d41587883229f7f139307126750