### PR TITLE
Fix missing bold formatting in headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+__pycache__/\ntmp/

--- a/ospro.py
+++ b/ospro.py
@@ -1175,7 +1175,8 @@ class MainWindow(QMainWindow):
         deposito_a = self._field_anchor(self.entry_deposito, "combo_deposito", "depósito")
         cuerpo = (
             "<b>A LA SRA. SECRETARIA PENAL</b>\n"
-            "<b>DEL TRIBUNAL SUPERIOR DE JUSTICIA  \nDRA. MARIA PUEYRREDON DE MONFARRELL</b>\n"
+            "<b>DEL TRIBUNAL SUPERIOR DE JUSTICIA</b>\n"
+            "<b>DRA. MARIA PUEYRREDON DE MONFARRELL</b>\n"
             "<b>S______/_______D:</b>\n\n"
             f"En los autos caratulados: {car_a}, que se tramitan por ante "
             f"{trib_a}, con conocimiento e intervención de esta Oficina de Servicios "
@@ -1224,7 +1225,8 @@ class MainWindow(QMainWindow):
 
         cuerpo = (
             "<b>A LA SRA. SECRETARIA PENAL</b>\n"
-            "<b>DEL TRIBUNAL SUPERIOR DE JUSTICIA  \nDRA. MARIA PUEYRREDON DE MONFARRELL</b>\n"
+            "<b>DEL TRIBUNAL SUPERIOR DE JUSTICIA</b>\n"
+            "<b>DRA. MARIA PUEYRREDON DE MONFARRELL</b>\n"
             "<b>S/D:</b>\n\n"
             f"En los autos caratulados: {car_a}, que se tramitan por ante "
             f"{trib_a}, con intervención de esta Oficina de Servicios Procesales "
@@ -1319,7 +1321,8 @@ class MainWindow(QMainWindow):
 
         cuerpo = (
             "<b>A LA SRA. SECRETARIA PENAL</b>\n"
-            "<b>DEL TRIBUNAL SUPERIOR DE JUSTICIA  \nDRA. MARIA PUEYRREDON DE MONFARRELL</b>\n"
+            "<b>DEL TRIBUNAL SUPERIOR DE JUSTICIA</b>\n"
+            "<b>DRA. MARIA PUEYRREDON DE MONFARRELL</b>\n"
             "<b>S______/_______D:</b>\n\n"
             f"En los autos caratulados: {car_a}, que se tramitan por ante "
             f"{trib_a}, con conocimiento e intervención de ésta Oficina de Servicios "


### PR DESCRIPTION
## Summary
- ensure `DRA. MARIA PUEYRREDON DE MONFARRELL` is bold in generated headers
- add `.gitignore` for temporary folders

## Testing
- `python3 -m py_compile ospro.py`

------
https://chatgpt.com/codex/tasks/task_b_688b56551698832294837875eea4e887