### PR TITLE
Implement punctuation cleanup for all oficios

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -170,6 +170,42 @@ def html_a_plano(html: str, mantener_saltos: bool = True) -> str:
         text = " ".join(text.splitlines())
     return text.strip()
 
+def strip_trailing_single_dot(text: str | None) -> str:
+    """
+    Elimina puntos redundantes sin romper las elipsis.
+
+    • Convierte cada ".." aislado (no precedido ni seguido por otro punto)
+      en un único ".", aun cuando los dos puntos estén separados sólo por
+      etiquetas de cierre HTML (</a>, </b>…), espacios o saltos de línea.
+    • Si aún quedasen dos o más puntos al final, los reduce a:
+        – "…"   → se mantiene (puntos suspensivos)
+        – "."   → un solo punto
+    """
+    if not text:
+        return ""
+
+    # ── 1)  ".." directos → "."  (como antes)
+    text = re.sub(r"(?<!\.)\.\.(?!\.)", ".", text)
+
+    # ── 2)  ".</tag>."   ó   ".</tag></b> ."  → sólo un punto
+    #        (punto  + etiquetas de cierre/espacios  + punto)
+    text = re.sub(
+        r"(?<!\.)"  # el char anterior NO es punto
+        r"\."  # un punto
+        r"(?:\s*</[^>]+>\s*)+"  # ≥1 etiquetas de cierre con posible white-space
+        r"\."  # otro punto
+        r"(?!\.)",  # el siguiente char NO es punto
+        lambda m: m.group(0)[:-1],  # suprime el último punto
+        text,
+    )
+
+    # ── 3)  Normalizar la cola ("….." → "…" | ".." → ".")
+    tail = re.search(r"\.*$", text).group(0)  # todos los puntos del final
+    if tail and tail not in ("...", "…"):
+        text = text[: -len(tail)] + "."
+
+    return text
+
 # ── helper para capturar el bloque dispositvo (resuelvo) ─────────────
 
 # ── helper para capturar SIEMPRE el bloque dispositvo (resuelvo) ──────────
@@ -1104,6 +1140,7 @@ class MainWindow(QMainWindow):
             "Se adjuntan al presente oficio copia digital de la misma y del cómputo de pena respectivo.\n\n"
             "Sin otro particular, saludo a Ud. atentamente."
         )
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
 
@@ -1148,6 +1185,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, saludo a Ud. atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_consulado(self):
@@ -1193,6 +1231,7 @@ class MainWindow(QMainWindow):
         )
 
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_registro_automotor(self):
@@ -1235,6 +1274,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, saludo a Ud. atte."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_tsj_secpenal(self):
@@ -1294,6 +1334,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, saludo a Ud. muy atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_tsj_secpenal_depositos(self):
@@ -1343,6 +1384,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, saludo a Ud. muy atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_comisaria_traslado(self):
@@ -1391,6 +1433,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, saludo a Ud. muy atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_tsj_secpenal_elementos(self):
@@ -1437,6 +1480,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, saludo a Ud. muy atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_automotores_secuestrados(self):
@@ -1483,6 +1527,7 @@ class MainWindow(QMainWindow):
             "Saludo a Ud. muy atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_fiscalia_instruccion(self):
@@ -1530,6 +1575,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, saludo a Ud. atte."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_policia_documentacion(self):
@@ -1596,6 +1642,7 @@ class MainWindow(QMainWindow):
             "Saluda a Ud. atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_registro_civil(self):
@@ -1635,6 +1682,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, saludo a Ud. atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_registro_condenados_sexuales(self):
@@ -1706,6 +1754,7 @@ class MainWindow(QMainWindow):
             "Saludo a Ud. atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_registro_nacional_reincidencia(self):
@@ -1752,6 +1801,7 @@ class MainWindow(QMainWindow):
             "Saluda a Ud. atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_repat(self):
@@ -1790,6 +1840,7 @@ class MainWindow(QMainWindow):
             "Saludo a Ud. atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_juzgado_ninez(self):
@@ -1841,6 +1892,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, saludo a Ud. atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def _plantilla_complejo_carcelario(self):
@@ -1882,6 +1934,7 @@ class MainWindow(QMainWindow):
             "Sin otro particular, lo saludo atentamente."
         )
         self._insert_paragraph(te, fecha, Qt.AlignRight)
+        cuerpo = strip_trailing_single_dot(cuerpo)
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def copy_to_clipboard(self, te: QTextEdit):


### PR DESCRIPTION
## Summary
- add `strip_trailing_single_dot` to normalize punctuation
- apply this cleaner to the generated text in every oficio template

## Testing
- `python3 -m py_compile ospro.py helpers.py`

------
https://chatgpt.com/codex/tasks/task_b_688b808a24a083229dfde162aac81a22