### PR TITLE
Remove hyperlinks from clipboard data

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -23,3 +23,9 @@ def anchor_html(html_text: str, clave: str, placeholder: str = None) -> str:
     )
     safe = html_text.replace("\n", "<br/>")
     return f'<a href="{clave}" style="{style}">{safe}</a>'
+
+
+def strip_anchors(html_text: str) -> str:
+    """Return ``html_text`` without ``<a>`` tags but keeping their content."""
+    import re
+    return re.sub(r"<a[^>]*>(.*?)</a>", r"\1", html_text, flags=re.DOTALL)

--- a/ospro.py
+++ b/ospro.py
@@ -51,7 +51,7 @@ import ast
 import subprocess
 import shutil
 import tempfile
-from helpers import anchor, anchor_html
+from helpers import anchor, anchor_html, strip_anchors
 
 # ──────────────────── utilidades menores ────────────────────
 class NoWheelComboBox(QComboBox):
@@ -1949,8 +1949,9 @@ class MainWindow(QMainWindow):
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def copy_to_clipboard(self, te: QTextEdit):
+        html = strip_anchors(te.toHtml())
         mime = QMimeData()
-        mime.setHtml(te.toHtml())
+        mime.setHtml(html)
         mime.setText(te.toPlainText())
         QApplication.clipboard().setMimeData(mime)
 


### PR DESCRIPTION
## Summary
- add helper to strip `<a>` tags
- use the helper when copying text to the clipboard

## Testing
- `python -m py_compile ospro.py helpers.py`

------
https://chatgpt.com/codex/tasks/task_b_688b832fda388322b630366c440176de