### PR TITLE
Clean anchor styling before copying

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -29,3 +29,16 @@ def strip_anchors(html_text: str) -> str:
     """Return ``html_text`` without ``<a>`` tags but keeping their content."""
     import re
     return re.sub(r"<a[^>]*>(.*?)</a>", r"\1", html_text, flags=re.DOTALL)
+
+
+def _strip_anchor_styles(html: str) -> str:
+    """Remove style attributes and ``<u>`` tags from anchor elements."""
+    import re
+    html = re.sub(
+        r"(<a[^>]+?)\s+style=(\"[^\"]*\"|'[^']*')",
+        r"\1",
+        html,
+        flags=re.IGNORECASE,
+    )
+    html = re.sub(r'</?u[^>]*>', '', html, flags=re.IGNORECASE)
+    return html

--- a/ospro.py
+++ b/ospro.py
@@ -51,7 +51,7 @@ import ast
 import subprocess
 import shutil
 import tempfile
-from helpers import anchor, anchor_html, strip_anchors
+from helpers import anchor, anchor_html, _strip_anchor_styles
 
 # ──────────────────── utilidades menores ────────────────────
 class NoWheelComboBox(QComboBox):
@@ -1961,7 +1961,7 @@ class MainWindow(QMainWindow):
         self._insert_paragraph(te, cuerpo, Qt.AlignJustify, rich=True)
 
     def copy_to_clipboard(self, te: QTextEdit):
-        html = strip_anchors(te.toHtml())
+        html = _strip_anchor_styles(te.toHtml())
         mime = QMimeData()
         mime.setHtml(html)
         mime.setText(te.toPlainText())


### PR DESCRIPTION
## Summary
- add helper to strip style and underline from anchor tags
- use helper when copying text to clipboard

## Testing
- `python -m py_compile helpers.py ospro.py`


------
https://chatgpt.com/codex/tasks/task_b_688b862fca2083229449d8f500f177f2