### PR TITLE
Fix DNI formatting in autocompletion

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -289,6 +289,13 @@ def normalizar_caratula(txt: str) -> str:
     return txt
 
 
+def normalizar_dni(txt: str) -> str:
+    """Devuelve solo los dígitos del DNI."""
+    if txt is None:
+        return ""
+    return re.sub(r"\D", "", str(txt))
+
+
 
 def extraer_firmantes(texto: str) -> list[dict]:
     """
@@ -1089,6 +1096,8 @@ class MainWindow(QMainWindow):
                 else:
                     nombre = self._as_str(imp.get("nombre"))
                     dni = self._as_str(imp.get("dni"))
+
+                dni = normalizar_dni(dni)
                 self.imputados_widgets[idx]["nombre"].setText(nombre)
                 self.imputados_widgets[idx]["dni"].setText(dni)
             self._refresh_imp_names_in_selector()


### PR DESCRIPTION
## Summary
- add `normalizar_dni` helper
- sanitize DNI values when filling imputado data

## Testing
- `python -m py_compile ospro.py helpers.py`

------
https://chatgpt.com/codex/tasks/task_b_688b86a1165c8322935c6318e4f66b18