### PR TITLE
Fix regex pattern in ospro

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -250,7 +250,7 @@ _RESUELVO_REGEX = re.compile(
     (                                   # ---------- BLOQUE A CAPTURAR ----------
         (?:\s*[IVXLCDM]+\s*[).]\s.*?     #  I) …   o   I. …
             (?:\n(?!\s*[IVXLCDM]+\s*[).]).*?)*   #   líneas que siguen al mismo inciso
-    )+                                  # uno o más incisos
+    )+)                                  # uno o más incisos
     (?=                                  # ---------- CONDICIÓN DE CORTE ----------
         \s*(?:\n|$)\s*                    #  debe empezar línea nueva (o fin de texto)
         (?:Protocol[íi]?cese              #  fórmulas de cierre habituales


### PR DESCRIPTION
## Summary
- fix `_RESUELVO_REGEX` to properly close the capture group preventing `re.PatternError`

## Testing
- `python ospro.py` *(fails: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_b_688b8e6e21b0832292f25faad5e2e4b1