### PR TITLE
Set anchor color to blue in UI

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -6,7 +6,7 @@ def anchor(texto: str, clave: str, placeholder: str = None) -> str:
     if not texto.strip():
         texto = placeholder or f"[{clave}]"
     style = (
-            "color:black;text-decoration:none;",
+        "color:blue;text-decoration:none;",
         "font-family:'Times New Roman';font-size:12pt;",
     )
     style_str = "".join(style)
@@ -19,7 +19,7 @@ def anchor_html(html_text: str, clave: str, placeholder: str = None) -> str:
     if not html_text.strip():
         return anchor("", clave, placeholder)
     style = (
-        "color:black;text-decoration:none;",
+        "color:blue;text-decoration:none;",
         "font-family:'Times New Roman';font-size:12pt;",
     )
     style_str = "".join(style)


### PR DESCRIPTION
## Summary
- style anchors in the UI using blue text
- keep copy behavior stripping anchor styles

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_688b9164be788322991c7403f8f5da2f