### PR TITLE
Remove hyperlink color when copying

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -44,3 +44,9 @@ def _strip_anchor_styles(html: str) -> str:
     )
     html = re.sub(r'</?u[^>]*>', '', html, flags=re.IGNORECASE)
     return html
+
+
+def strip_color(html: str) -> str:
+    """Remove CSS ``color`` declarations so text defaults to black."""
+    import re
+    return re.sub(r"(?<!-)color\s*:[^;\"']*;?", '', html, flags=re.IGNORECASE)

--- a/ospro.py
+++ b/ospro.py
@@ -51,7 +51,7 @@ import ast
 import subprocess
 import shutil
 import tempfile
-from helpers import anchor, anchor_html, strip_anchors, _strip_anchor_styles
+from helpers import anchor, anchor_html, strip_anchors, _strip_anchor_styles, strip_color
 
 # ──────────────────── utilidades menores ────────────────────
 class NoWheelComboBox(QComboBox):
@@ -73,6 +73,7 @@ class PlainCopyTextBrowser(QTextBrowser):
         if html:
             html = _strip_anchor_styles(html)
             html = strip_anchors(html)
+            html = strip_color(html)
             new_mime = QMimeData()
             new_mime.setHtml(html)
             new_mime.setText(mime.text())
@@ -2026,6 +2027,7 @@ class MainWindow(QMainWindow):
     def copy_to_clipboard(self, te: QTextEdit):
         html = _strip_anchor_styles(te.toHtml())
         html = strip_anchors(html)
+        html = strip_color(html)
         mime = QMimeData()
         mime.setHtml(html)
         mime.setText(te.toPlainText())


### PR DESCRIPTION
## Summary
- add `strip_color` helper to remove CSS color properties
- ensure copy operations use `strip_color` so anchor text is black when pasted

## Testing
- `python3 -m py_compile ospro.py helpers.py`


------
https://chatgpt.com/codex/tasks/task_b_688b93d46838832282a144e9dc9ed214