### PR TITLE
Improve clipboard handling for Windows

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -50,3 +50,42 @@ def strip_color(html: str) -> str:
     """Remove CSS ``color`` declarations so text defaults to black."""
     import re
     return re.sub(r"(?<!-)color\s*:[^;\"']*;?", '', html, flags=re.IGNORECASE)
+
+
+def create_clipboard_html(html_data: str) -> str:
+    """Return ``html_data`` packaged for the Windows clipboard."""
+    start_marker = "<!--StartFragment-->"
+    end_marker = "<!--EndFragment-->"
+
+    start_fragment = html_data.find(start_marker)
+    end_fragment = html_data.find(end_marker)
+
+    if start_fragment == -1:
+        start_fragment = 0
+    else:
+        start_fragment += len(start_marker)
+
+    if end_fragment == -1:
+        end_fragment = len(html_data)
+
+    html_header = """Version:0.9
+StartHTML:{0:010d}
+EndHTML:{1:010d}
+StartFragment:{2:010d}
+EndFragment:{3:010d}
+StartSelection:{2:010d}
+EndSelection:{3:010d}
+"""
+
+    html_bytes = html_data.encode("utf-8")
+    temp_header = html_header.format(0, 0, 0, 0)
+    start_html = len(temp_header)
+    end_html = start_html + len(html_bytes)
+
+    fragment_start = start_html + start_fragment
+    fragment_end = start_html + end_fragment
+
+    final_header = html_header.format(
+        start_html, end_html, fragment_start, fragment_end
+    )
+    return final_header + html_data


### PR DESCRIPTION
## Summary
- support HTML `CF_HTML` clipboard format on Windows for better pasting
- expose helper `create_clipboard_html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688b9855341083229fe17b259a0fa761