### PR TITLE
Fix Juzgado NAVFyG anchor editing

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -2462,7 +2462,18 @@ class MainWindow(QMainWindow):
             editable=widget.isEditable(),
         )
         if ok:
-            widget.setCurrentText(texto.strip())
+            texto = texto.strip()
+            # ``QInputDialog`` may normalize spaces (e.g. replace narrow no-break
+            # spaces with regular ones) which prevents ``setCurrentText`` from
+            # matching the existing combo item and updating its current data.
+            # Map normalized item texts to their indices to ensure we select the
+            # correct entry when possible.
+            norm_map = {it.replace("\u202f", " "): i for i, it in enumerate(items)}
+            idx_new = norm_map.get(texto.replace("\u202f", " "), -1)
+            if idx_new >= 0:
+                widget.setCurrentIndex(idx_new)
+            else:
+                widget.setCurrentText(texto)
             self.update_templates()
 
     def _check_caratula(self) -> None:


### PR DESCRIPTION
## Summary
- ensure QInputDialog selections update the underlying combo data by normalizing spaces in `_editar_combo`

## Testing
- `python -m py_compile helpers.py ospro.py`


------
https://chatgpt.com/codex/tasks/task_b_688ea690056883228cfb08e8f60899a9