### PR TITLE
Handle line breaks for Niñez courts with severe cases

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -2307,6 +2307,9 @@ class MainWindow(QMainWindow):
         if juz.startswith("Juzgado de Niñez,"):
             juz = (juz.replace(", Violencia", ",\nViolencia")
                       .replace("Género de ", "Género de \n"))
+        elif "modalidad doméstica -causas graves-" in juz:
+            juz = (juz.replace(", modalidad", ",\nmodalidad")
+                      .replace("-causas graves- de", "-causas graves-\nde"))
         ee_rel = self._imp_field('ee_relacionado') or "…………."
         nombre = self._imp_field('nombre') or "\u2026"
         dni = self._imp_field('dni') or "\u2026"


### PR DESCRIPTION
## Summary
- Split long headers for severe domestic-violence Niñez courts, matching other Niñez formatting.

## Testing
- `python -m py_compile helpers.py ospro.py`

------
https://chatgpt.com/codex/tasks/task_b_688ea85bfdec83228bbcbcee3b0a3eb3