### PR TITLE
Eliminar encabezado RESUELVE del campo resuelvo

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -496,6 +496,10 @@ def extraer_resuelvo(texto: str) -> str:
 
     # 3) prolijo
     frag = frag.strip()
+
+    # quitar encabezado "RESUELVE:" / "RESUELVO:" si quedó incluido
+    frag = re.sub(r"^resuelv[eo]\s*:?\s*", "", frag, flags=re.I)
+
     return frag
 
 

--- a/tests/test_resuelvo.py
+++ b/tests/test_resuelvo.py
@@ -74,4 +74,13 @@ def test_extraer_resuelvo_removes_digital_signature():
     )
     res = ospro.extraer_resuelvo(texto)
     assert "Firmado digitalmente" not in res
-    assert res == "RESUELVO:\n1) Ordenar algo.\n2) Otra cosa."
+    assert res == "1) Ordenar algo.\n2) Otra cosa."
+
+
+def test_extraer_resuelvo_strips_heading():
+    texto = (
+        "Texto previo\n"
+        "Se RESUELVE: Primero. Algo. Segundo. Otra cosa.\n"
+    )
+    res = ospro.extraer_resuelvo(texto)
+    assert res == "Primero. Algo. Segundo. Otra cosa."


### PR DESCRIPTION
## Summary
- El campo `resuelvo` ya no conserva el encabezado "RESUELVE:"/"RESUELVO:" tras la extracción del texto.
- Se actualizó y amplió la suite de pruebas para verificar que se elimine el encabezado y la firma digital.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688f53e0fecc8322bcbad71ac46f7f65