### PR TITLE
feat: guardar API key de OpenAI

### DIFF
--- a/ospro.py
+++ b/ospro.py
@@ -2514,16 +2514,40 @@ class MainWindow(QMainWindow):
             ev.ignore()
 
 # ──────────────────────────── main ───────────────────────────────
+def _obtener_api_key() -> str:
+    """Devuelve la API key desde el entorno o un archivo."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        return api_key
+
+    key_file = Path.home() / ".openai_api_key"
+    if key_file.exists():
+        api_key = key_file.read_text().strip()
+        if api_key:
+            os.environ["OPENAI_API_KEY"] = api_key
+            return api_key
+
+    api_key, ok = QInputDialog.getText(
+        None,
+        "API Key de OpenAI",
+        "Ingresá tu clave de OpenAI",
+    )
+    if not ok or not api_key:
+        QMessageBox.critical(None, "Error", "Falta la variable OPENAI_API_KEY")
+        sys.exit(1)
+    os.environ["OPENAI_API_KEY"] = api_key
+    try:
+        key_file.write_text(api_key)
+    except OSError:
+        pass
+    return api_key
+
+
 def main():
     app = QApplication(sys.argv)
     app.setWindowIcon(QIcon(resource_path("icono4.ico")))
-
     # ahora SÍ podés usar QMessageBox
-    if not os.getenv("OPENAI_API_KEY"):
-        QMessageBox.critical(
-            None, "Error", "Falta la variable OPENAI_API_KEY"
-        )
-        sys.exit(1)
+    openai.api_key = _obtener_api_key()
 
     win = MainWindow()
     win.show()


### PR DESCRIPTION
## Summary
- Guardar la API key en un archivo en el directorio de usuario para reutilizarla automáticamente.
- Configurar `openai.api_key` tomando la clave del entorno o del archivo.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689366bb0454832281bd5af4e125350a