### PR TITLE
Remove DOCX generator

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,6 +1,5 @@
 # api.py
 from fastapi import FastAPI, UploadFile, File, HTTPException
-from fastapi.responses import Response
 import core
 
 app = FastAPI(title="Generador OSPRO")
@@ -13,16 +12,3 @@ async def autocompletar(file: UploadFile = File(...)):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/oficios")
-async def oficios(payload: dict):
-    try:
-        docx_bytes = core.generar_oficios(payload)
-        return Response(
-            content=docx_bytes,
-            media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            headers={
-                "Content-Disposition": 'attachment; filename="oficios.docx"'
-            },
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))

--- a/app.py
+++ b/app.py
@@ -1,36 +1,10 @@
 # app.py  – versión resumida
 import streamlit as st
-from core import autocompletar, generar_oficios   # ← mismas funciones
+from core import autocompletar   # ← función principal
 from datetime import datetime
 from helpers import anchor, strip_anchors
 
 st.set_page_config(page_title="OSPRO – Oficios", layout="wide")
-st.divider()
-st.subheader("Descarga")
-
-if st.button("Generar DOCX con todos los oficios"):
-    payload = {
-        "generales": {
-            "caratula":  st.session_state.carat,
-            "tribunal":  st.session_state.trib,
-            "sent_num":  st.session_state.snum,
-            "sent_fecha":st.session_state.sfecha,
-            "resuelvo":  st.session_state.sres,
-            "firmantes": st.session_state.sfirmaza,
-        },
-        "imputados": [
-            {
-                "datos_personales": st.session_state.get(f"imp{i}_datos",""),
-                "nombre":           st.session_state.get(f"imp{i}_nom",""),
-                "dni":              st.session_state.get(f"imp{i}_dni",""),
-            }
-            for i in range(st.session_state.n_imputados)
-        ],
-    }
-    docx = generar_oficios(payload)
-    st.download_button("Descargar oficios.docx", docx,
-                       file_name="oficios.docx",
-                       mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document")
 
 # ───────── helpers comunes ──────────────────────────────────────────
 MESES_ES = ["enero","febrero","marzo","abril","mayo","junio",

--- a/core.py
+++ b/core.py
@@ -3,19 +3,15 @@
 core.py – capa lógica pura de OSPRO
 -----------------------------------
 
-La app web necesita dos nombres públicos:
+La app web expone un único nombre público:
 
     autocompletar(file_bytes, filename) -> None
         Extrae los datos y rellena st.session_state.
-
-    generar_oficios(payload) -> bytes
-        Devuelve un DOCX en memoria con los oficios.
 
 ¡Nada más!  El resto son utilidades internas.
 """
 from __future__ import annotations
 
-import io
 import json
 import re
 import tempfile
@@ -26,7 +22,6 @@ from typing import Any, List, Dict
 import docx2txt
 import openai
 import streamlit as st            # ← para volcar datos en la UI
-from docx import Document         # python-docx
 from pdfminer.high_level import extract_text
 
 # ────────────────────────── Config ──────────────────────────
@@ -230,39 +225,8 @@ def autocompletar(file_bytes: bytes, filename: str) -> None:
         st.session_state.setdefault(f"{key}_datos", "")
 
 
-# ────────────────── Generador de DOCX demo ──────────────────
-def generar_oficios(payload: dict[str, Any]) -> bytes:
-    """Crea un DOCX muy simple con los datos recibidos."""
-    doc = Document()
-    g = payload.get("generales", {})
-
-    doc.add_heading("Oficios automáticos", level=1)
-    doc.add_paragraph(f"Carátula: {g.get('caratula', '…')}")
-    doc.add_paragraph(f"Tribunal: {g.get('tribunal', '…')}")
-    doc.add_paragraph(
-        f"Sentencia N°: {g.get('sent_num', '…')} – Fecha: {g.get('sent_fecha', '…')}"
-    )
-    doc.add_paragraph("\nResuelvo:")
-    doc.add_paragraph(g.get("resuelvo", "…"))
-
-    doc.add_page_break()
-    for idx, imp in enumerate(payload.get("imputados", []), 1):
-        doc.add_heading(f"Imputado {idx}", level=2)
-        dp = imp.get("datos_personales", {}) or {}
-        if isinstance(dp, dict):
-            for k, v in dp.items():
-                doc.add_paragraph(f"{k.capitalize()}: {v}")
-        else:
-            doc.add_paragraph(str(dp))
-        doc.add_paragraph("")
-
-    bio = io.BytesIO()
-    doc.save(bio)
-    return bio.getvalue()
-
-
 # ────────────────── API pública ─────────────────────────────
-__all__ = ["autocompletar", "generar_oficios"]
+__all__ = ["autocompletar"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Remove the legacy `generar_oficios` DOCX creation logic and stop exporting it from the core module.
- Drop all UI and API hooks related to DOCX generation, leaving only the `autocompletar` functionality.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68939cf8a59483228c13f25ecb6d908b