### PR TITLE
Add dialog editing for anchors in Streamlit app

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,75 @@ st.set_page_config(page_title="OSPRO – Oficios", layout="wide")
 MESES_ES = ["enero","febrero","marzo","abril","mayo","junio",
             "julio","agosto","septiembre","octubre","noviembre","diciembre"]
 
+# listado básico de tribunales para el cuadro de diálogo
+TRIBUNALES = [
+    "la Cámara en lo Criminal y Correccional de Primera Nominación",
+    "la Cámara en lo Criminal y Correccional de Segunda Nominación",
+    "la Cámara en lo Criminal y Correccional de Tercera Nominación",
+    "la Cámara en lo Criminal y Correccional de Cuarta Nominación",
+    "la Cámara en lo Criminal y Correccional de Quinta Nominación",
+    "la Cámara en lo Criminal y Correccional de Sexta Nominación",
+    "la Cámara en lo Criminal y Correccional de Séptima Nominación",
+    "la Cámara en lo Criminal y Correccional de Octava Nominación",
+    "la Cámara en lo Criminal y Correccional de Novena Nominación",
+    "la Cámara en lo Criminal y Correccional de Décima Nominación",
+    "la Cámara en lo Criminal y Correccional de Onceava Nominación",
+    "la Cámara en lo Criminal y Correccional de Doceava Nominación",
+    "el Juzgado de Control en lo Penal Económico",
+    "el Juzgado de Control y Faltas N° 2",
+    "el Juzgado de Control y Faltas N° 3",
+    "el Juzgado de Control y Faltas N° 4",
+    "el Juzgado de Control y Faltas N° 5",
+    "el Juzgado de Control en Violencia de Género y Familiar N° 1",
+    "el Juzgado de Control en Violencia de Género y Familiar N° 2",
+    "el Juzgado de Control y Faltas N° 7",
+    "el Juzgado de Control y Faltas N° 8",
+    "el Juzgado de Control y Faltas N° 9",
+    "el Juzgado de Control y Faltas N° 10",
+    "el Juzgado de Control y Faltas N° 11",
+    "el Juzgado de Control de Lucha contra el Narcotráfico",
+]
+
+
+# relación entre anchors y widgets a mostrar en el cuadro de diálogo
+ANCHOR_FIELDS = {
+    "caratula": ("Carátula", "text", "carat"),
+    "tribunal": ("Tribunal", "select", "trib"),
+    "snum": ("Sentencia N°", "text", "snum"),
+    "sfecha": ("Fecha sentencia", "text", "sfecha"),
+    "sfirmeza": ("Firmeza sentencia", "text", "sfirmeza"),
+    "sres": ("Resuelvo", "textarea", "sres"),
+    "sfirmaza": ("Firmantes", "text", "sfirmaza"),
+    "imp0_datos": ("Datos personales", "textarea", "imp0_datos"),
+    "consulado": ("Consulado", "text", "consulado"),
+}
+
+
+def _mostrar_dialogo(clave: str) -> None:
+    campo = ANCHOR_FIELDS.get(clave)
+    if not campo:
+        return
+    titulo, tipo, estado = campo
+    valor_actual = st.session_state.get(estado, "")
+    with st.modal(titulo):
+        if tipo == "text":
+            nuevo = st.text_input(titulo, valor_actual, key=f"dlg_{estado}")
+        elif tipo == "textarea":
+            nuevo = st.text_area(titulo, valor_actual, key=f"dlg_{estado}")
+        elif tipo == "select":
+            idx = TRIBUNALES.index(valor_actual) if valor_actual in TRIBUNALES else 0
+            nuevo = st.selectbox(titulo, TRIBUNALES, index=idx, key=f"dlg_{estado}")
+        else:
+            nuevo = valor_actual
+        col_a, col_b = st.columns(2)
+        if col_a.button("Aceptar", key=f"ok_{estado}"):
+            st.session_state[estado] = nuevo
+            st.experimental_set_query_params()
+            st.experimental_rerun()
+        if col_b.button("Cancelar", key=f"cancel_{estado}"):
+            st.experimental_set_query_params()
+            st.experimental_rerun()
+
 def fecha_alineada(loc: str, fecha=None, punto=False):
     d = fecha or datetime.now()
     txt = f"{loc}, {d.day} de {MESES_ES[d.month-1]} de {d.year}"
@@ -37,6 +106,12 @@ def fecha_alineada(loc: str, fecha=None, punto=False):
 # ───────── estado de sesión ─────────────────────────────────────────
 if "n_imputados" not in st.session_state: st.session_state.n_imputados = 1
 if "datos_autocompletados" not in st.session_state: st.session_state.datos_autocompletados = {}
+
+# si hay un parámetro de consulta ``anchor`` mostramos el diálogo correspondiente
+_params = st.experimental_get_query_params()
+_anchor_clicked = _params.get("anchor", [None])[0]
+if _anchor_clicked:
+    _mostrar_dialogo(_anchor_clicked)
 
 # ───────── barra lateral (datos generales) ──────────────────────────
 with st.sidebar:
@@ -185,3 +260,20 @@ with tabs[2]:
     if st.button("Copiar", key="copy_electoral"):
         texto = strip_anchors(cuerpo + saludo).replace("<br>", "\n")
         copy_to_clipboard(texto)
+
+
+# ───────── manejo de clics en anchors ───────────────────────────────
+ANCHOR_JS = """
+<script>
+document.addEventListener('click', function(e) {
+  const a = e.target.closest('a[data-anchor]');
+  if (a) {
+    e.preventDefault();
+    const params = new URLSearchParams(window.location.search);
+    params.set('anchor', a.getAttribute('data-anchor'));
+    window.location.search = params.toString();
+  }
+});
+</script>
+"""
+st.markdown(ANCHOR_JS, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- Enable editing of anchor placeholders in the Streamlit app via modal dialogs.
- Map anchor identifiers to dialog widgets and session state fields.
- Add JavaScript handler to capture anchor clicks and trigger dialogs.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6893a046b5c4832289a8c8caf1cee039