### PR TITLE
Add debug traces for anchor links

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,6 +89,7 @@ def _mostrar_dialogo(clave: str) -> None:
     Si ``clave`` corresponde a un imputado (``edit_imp{n}_datos``) el índice
     se extrae dinámicamente; de lo contrario se consulta :data:`ANCHOR_FIELDS`.
     """
+    print("Dentro de _mostrar_dialogo:", clave)
 
     if clave.startswith("edit_imp") and clave.endswith("_datos"):
         idx = int(re.search(r"edit_imp(\d+)_datos", clave).group(1))
@@ -132,8 +133,10 @@ if "datos_autocompletados" not in st.session_state: st.session_state.datos_autoc
 
 # si hay un parámetro de consulta ``anchor`` mostramos el diálogo correspondiente
 _params = st.experimental_get_query_params()
+print("query params:", _params)
 _anchor_clicked = _params.get("anchor", [None])[0]
 if _anchor_clicked:
+    print("Abrir modal para:", _anchor_clicked)
     _mostrar_dialogo(_anchor_clicked)
 
 # ───────── barra lateral (datos generales) ──────────────────────────
@@ -302,6 +305,7 @@ if "_js_anchor_patch" not in st.session_state:
 
             e.preventDefault();                     // cancelamos el click
             const anchor = link.getAttribute('data-anchor');
+            console.log('clic anchor', anchor);
 
             // Actualizamos ?anchor=... en la URL del navegador
             const url = new URL(window.parent.location);

--- a/helpers.py
+++ b/helpers.py
@@ -2,7 +2,13 @@ import html
 
 
 def anchor(texto: str, clave: str, placeholder: str = None) -> str:
-    """Devuelve un enlace HTML plano"""
+    """Devuelve un enlace HTML plano.
+
+    Además imprime el HTML generado para ayudar en la depuración del flujo
+    de *anchor-links* dentro de la aplicación Streamlit.  De esta manera
+    puede verificarse desde la consola si cada ``data-anchor`` se crea con
+    la clave correcta.
+    """
     if not texto.strip():
         texto = placeholder or f"[{clave}]"
     style = (
@@ -11,7 +17,9 @@ def anchor(texto: str, clave: str, placeholder: str = None) -> str:
     )
     style_str = "".join(style)
     safe = html.escape(texto).replace("\n", "<br/>")
-    return f'<a href="#" data-anchor="{clave}" onclick="return false;" style="{style_str}">{safe}</a>'
+    html_link = f'<a href="#" data-anchor="{clave}" onclick="return false;" style="{style_str}">{safe}</a>'
+    print("HTML anchor:", html_link)
+    return html_link
 
 
 def anchor_html(html_text: str, clave: str, placeholder: str = None) -> str:


### PR DESCRIPTION
## Summary
- log generated HTML anchors to trace helper output
- report query parameters and clicked anchors, including modal calls
- console-log anchor clicks to inspect JavaScript handler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6893c12fd48c8322a797d7c12533f0f2