### PR TITLE
Fix dialog modal for anchor editing

### DIFF
--- a/app.py
+++ b/app.py
@@ -133,7 +133,7 @@ def _mostrar_dialogo(clave: str) -> None:
         titulo, tipo, estado = campo
 
     valor_actual = st.session_state.get(estado, "")
-    with st.modal(titulo):
+    with st.dialog(titulo):
         if tipo == "text":
             nuevo = st.text_input(titulo, valor_actual, key=f"dlg_{estado}")
         elif tipo == "textarea":


### PR DESCRIPTION
## Summary
- Replace `st.modal` with correct `st.dialog` so anchor links open dialogs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6893c6cd282c8322bf4c7c7879ae65e0