### PR TITLE
Replace dialog anchors with inline editable spans

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,24 +66,23 @@ def _html_compat(content: str, *, height: int = 0, width: int = 0):
 # -------------------------------------------------------------------
 js_code = """
 <script>
-/* Captura clicks en elementos con clase dlg-link y envía la clave a Streamlit */
+/* Envía a Streamlit los cambios en elementos editables */
 (function () {
   const parent = window.parent;
   const doc = parent.document;
 
-  if (parent.__ospro_dlg_handler__)
-      doc.removeEventListener('click', parent.__ospro_dlg_handler__, true);
+  if (parent.__ospro_edit_handler__)
+      doc.removeEventListener('focusout', parent.__ospro_edit_handler__, true);
 
-  let seq = 0;
   function handler(e) {
-    const el = e.target.closest('.dlg-link');
+    const el = e.target.closest('.editable');
     if (!el) return;
-    e.preventDefault();
-    Streamlit.setComponentValue({key: el.dataset.key, seq: seq++});
+    const val = el.innerText;
+    Streamlit.setComponentValue({key: el.dataset.key, value: val});
   }
 
-  doc.addEventListener('click', handler, true);
-  parent.__ospro_dlg_handler__ = handler;
+  doc.addEventListener('focusout', handler, true);
+  parent.__ospro_edit_handler__ = handler;
 
   Streamlit.setComponentReady();
   Streamlit.setFrameHeight(0);
@@ -92,136 +91,37 @@ js_code = """
 """
 
 # ⬇️  aquí ya no fallará, sea cual sea tu versión de Streamlit
-dialog_event = _html_compat(js_code, height=0, width=0)
+edit_event = _html_compat(js_code, height=0, width=0)
 
 # ───────── helpers comunes ──────────────────────────────────────────
-MESES_ES = ["enero","febrero","marzo","abril","mayo","junio",
-            "julio","agosto","septiembre","octubre","noviembre","diciembre"]
-
-# listado básico de tribunales para el cuadro de diálogo
-TRIBUNALES = [
-    "la Cámara en lo Criminal y Correccional de Primera Nominación",
-    "la Cámara en lo Criminal y Correccional de Segunda Nominación",
-    "la Cámara en lo Criminal y Correccional de Tercera Nominación",
-    "la Cámara en lo Criminal y Correccional de Cuarta Nominación",
-    "la Cámara en lo Criminal y Correccional de Quinta Nominación",
-    "la Cámara en lo Criminal y Correccional de Sexta Nominación",
-    "la Cámara en lo Criminal y Correccional de Séptima Nominación",
-    "la Cámara en lo Criminal y Correccional de Octava Nominación",
-    "la Cámara en lo Criminal y Correccional de Novena Nominación",
-    "la Cámara en lo Criminal y Correccional de Décima Nominación",
-    "la Cámara en lo Criminal y Correccional de Onceava Nominación",
-    "la Cámara en lo Criminal y Correccional de Doceava Nominación",
-    "el Juzgado de Control en lo Penal Económico",
-    "el Juzgado de Control y Faltas N° 2",
-    "el Juzgado de Control y Faltas N° 3",
-    "el Juzgado de Control y Faltas N° 4",
-    "el Juzgado de Control y Faltas N° 5",
-    "el Juzgado de Control en Violencia de Género y Familiar N° 1",
-    "el Juzgado de Control en Violencia de Género y Familiar N° 2",
-    "el Juzgado de Control y Faltas N° 7",
-    "el Juzgado de Control y Faltas N° 8",
-    "el Juzgado de Control y Faltas N° 9",
-    "el Juzgado de Control y Faltas N° 10",
-    "el Juzgado de Control y Faltas N° 11",
-    "el Juzgado de Control de Lucha contra el Narcotráfico",
+MESES_ES = [
+    "enero",
+    "febrero",
+    "marzo",
+    "abril",
+    "mayo",
+    "junio",
+    "julio",
+    "agosto",
+    "septiembre",
+    "octubre",
+    "noviembre",
+    "diciembre",
 ]
 
-
-"""Definiciones de cuadros de diálogo para cada elemento interactivo.
-
-Los nombres de clave siguen la convención utilizada en ``ospro.py``:
-
-``edit_`` → abre un cuadro con :func:`st.text_input` o :func:`st.text_area`.
-``combo_`` → abre un cuadro con :func:`st.selectbox`.
-"""
-
-DIALOG_FIELDS = {
-    "edit_caratula": ("Carátula", "text", "carat"),
-    "combo_tribunal": ("Tribunal", "select", "trib"),
-    "edit_sent_num": ("Sentencia N°", "text", "snum"),
-    "edit_sent_fecha": ("Fecha sentencia", "text", "sfecha"),
-    "edit_sent_firmeza": ("Firmeza sentencia", "text", "sfirmeza"),
-    "edit_resuelvo": ("Resuelvo", "textarea", "sres"),
-    "edit_firmantes": ("Firmantes", "text", "sfirmaza"),
-    "edit_consulado": ("Consulado", "text", "consulado"),
-    "edit_localidad": ("Localidad", "text", "loc"),
+# Mapeo de claves de elementos editables → keys del estado de sesión
+FIELD_MAP = {
+    "edit_caratula": "carat",
+    "combo_tribunal": "trib",
+    "edit_sent_num": "snum",
+    "edit_sent_fecha": "sfecha",
+    "edit_sent_firmeza": "sfirmeza",
+    "edit_resuelvo": "sres",
+    "edit_firmantes": "sfirmaza",
+    "edit_consulado": "consulado",
+    "edit_localidad": "loc",
 }
 
-
-# ───────── helper de compatibilidad ─────────────────────────────────
-def _open_dialog(title: str):
-    """
-    Devuelve el context-manager adecuado para abrir un cuadro modal,
-    sea `st.dialog` (Streamlit ≥ 1.30) o `st.modal` (versiones anteriores).
-    """
-    DialogCM = getattr(st, "dialog", None) or getattr(st, "modal", None)
-    if DialogCM is None:
-        raise RuntimeError("La versión de Streamlit instalada no soporta diálogos.")
-    return DialogCM(title)
-
-
-# ───────── función actualizada ─────────────────────────────────────
-def _mostrar_dialogo(clave: str) -> None:
-    """Abre el diálogo correspondiente al elemento clickeado.
-
-    Soporta:
-      • Streamlit ≥ 1.37 ─ `st.dialog` actúa como context-manager.
-      • Streamlit 1.30-1.36 ─ `st.dialog` actúa como decorador.
-      • Streamlit ≤ 1.29 ─ solo existe `st.modal` (context-manager).
-    """
-    print("Dentro de _mostrar_dialogo:", clave)
-
-    # ── identificar título, tipo de control y clave de estado ──
-    if clave.startswith("edit_imp") and clave.endswith("_datos"):
-        idx = int(re.search(r"edit_imp(\d+)_datos", clave).group(1))
-        titulo, tipo, estado = ("Datos personales", "textarea", f"imp{idx}_datos")
-    else:
-        campo = DIALOG_FIELDS.get(clave)
-        if not campo:         # clave desconocida → nada que hacer
-            return
-        titulo, tipo, estado = campo
-
-    valor_actual = st.session_state.get(estado, "")
-
-    # ── obtenemos la “fábrica” de diálogos disponible ──
-    DialogFactory = getattr(st, "dialog", None) or getattr(st, "modal", None)
-    if DialogFactory is None:
-        st.error("Tu versión de Streamlit no soporta cuadros de diálogo.")
-        return
-
-    # Streamlit nuevo ⇒ DialogFactory(titulo) ES context-manager
-    # Streamlit intermedio ⇒ DialogFactory(titulo) ES decorador (callable)
-    dialog_obj = DialogFactory(titulo)
-
-    def cuerpo_dialogo():
-        """Contenido común del cuadro (inputs + botones)."""
-        if tipo == "text":
-            nuevo = st.text_input(titulo, valor_actual, key=f"dlg_{estado}")
-        elif tipo == "textarea":
-            nuevo = st.text_area(titulo, valor_actual, key=f"dlg_{estado}")
-        elif tipo == "select":
-            idx = TRIBUNALES.index(valor_actual) if valor_actual in TRIBUNALES else 0
-            nuevo = st.selectbox(titulo, TRIBUNALES, index=idx, key=f"dlg_{estado}")
-        else:
-            nuevo = valor_actual
-
-        col_a, col_b = st.columns(2)
-        if col_a.button("Aceptar", key=f"ok_{estado}"):
-            st.session_state[estado] = nuevo
-            st.rerun()
-        if col_b.button("Cancelar", key=f"cancel_{estado}"):
-            st.rerun()
-
-    # ── distingimos si dialog_obj es context-manager o decorador ──
-    if hasattr(dialog_obj, "__enter__"):          # context-manager
-        with dialog_obj:
-            cuerpo_dialogo()
-    else:                                         # decorador
-        @dialog_obj
-        def _inner():
-            cuerpo_dialogo()
-        _inner()   # abre el cuadro
 
 def fecha_alineada(loc: str, fecha=None, punto=False):
     d = fecha or datetime.now()
@@ -229,13 +129,23 @@ def fecha_alineada(loc: str, fecha=None, punto=False):
     return txt + ("." if punto else "")
 
 # ───────── estado de sesión ─────────────────────────────────────────
-if "n_imputados" not in st.session_state: st.session_state.n_imputados = 1
-if "datos_autocompletados" not in st.session_state: st.session_state.datos_autocompletados = {}
+if "n_imputados" not in st.session_state:
+    st.session_state.n_imputados = 1
+if "datos_autocompletados" not in st.session_state:
+    st.session_state.datos_autocompletados = {}
 
-if isinstance(dialog_event, dict):
-    clave = dialog_event.get("key")
-    if isinstance(clave, str) and clave:
-        _mostrar_dialogo(clave)
+if isinstance(edit_event, dict):
+    clave = edit_event.get("key")
+    valor = edit_event.get("value")
+    if isinstance(clave, str) and isinstance(valor, str):
+        if clave.startswith("edit_imp") and clave.endswith("_datos"):
+            idx = int(re.search(r"edit_imp(\d+)_datos", clave).group(1))
+            st.session_state[f"imp{idx}_datos"] = valor
+        else:
+            estado = FIELD_MAP.get(clave)
+            if estado:
+                st.session_state[estado] = valor
+        st.rerun()
 
 
 # ───────── barra lateral (datos generales) ──────────────────────────

--- a/helpers.py
+++ b/helpers.py
@@ -3,21 +3,22 @@ import re
 
 
 def dialog_link(texto: str, clave: str, placeholder: str | None = None) -> str:
-    """Return a clickable link used to trigger dialogs.
+    """Return an inline editable element linked to ``clave``.
 
-    The element is rendered as ``<a class="dlg-link" data-key="...">`` so that
-    both the PySide6 application (which relies on ``href`` attributes) and the
-    web frontend can intercept clicks without recargar la página ni abrir una
-    pestaña nueva.
+    Instead of generating an ``<a>`` tag that abre un cuadro de diálogo, the
+    new implementation produces a ``<span>`` con ``contenteditable``.  Editing
+    the highlighted text sends its contenido to la aplicación mediante
+    JavaScript, permitiendo actualizar el campo correspondiente en la barra
+    lateral sin abrir ventanas modales.
     """
 
     if not texto.strip():
         texto = placeholder or f"[{clave}]"
     safe = html.escape(texto).replace("\n", "<br/>")
-    style = "color:blue;text-decoration:none;cursor:pointer;"
+    style = "color:blue;"
     return (
-        f'<a class="dlg-link" data-key="{clave}" href="{clave}" '
-        f'style="{style}">{safe}</a>'
+        f'<span class="editable" data-key="{clave}" contenteditable="true" '
+        f'style="{style}">{safe}</span>'
     )
 
 
@@ -27,29 +28,29 @@ def dialog_link_html(html_text: str, clave: str, placeholder: str | None = None)
     if not html_text.strip():
         return dialog_link("", clave, placeholder)
     style = (
-        "color:blue;text-decoration:none;cursor:pointer;",
+        "color:blue;",
         "font-family:'Times New Roman';font-size:12pt;",
     )
     style_str = "".join(style)
     safe = html_text.replace("\n", "<br/>")
     return (
-        f'<a class="dlg-link" data-key="{clave}" href="{clave}" '
-        f'style="{style_str}">{safe}</a>'
+        f'<span class="editable" data-key="{clave}" contenteditable="true" '
+        f'style="{style_str}">{safe}</span>'
     )
 
 
 def strip_dialog_links(html_text: str) -> str:
-    """Return ``html_text`` without ``a.dlg-link`` elements."""
+    """Return ``html_text`` without ``span.editable`` elements."""
 
-    pattern = r"<a[^>]*class=['\"]dlg-link['\"][^>]*>(.*?)</a>"
+    pattern = r"<span[^>]*class=['\"]editable['\"][^>]*>(.*?)</span>"
     return re.sub(pattern, r"\1", html_text, flags=re.DOTALL)
 
 
 def _strip_dialog_styles(html_text: str) -> str:
-    """Remove inline styles and ``<u>`` tags from dialog triggers."""
+    """Remove inline styles and ``<u>`` tags from editable spans."""
 
     html_text = re.sub(
-        r"(<a[^>]*class=['\"]dlg-link['\"][^>]*?)\s+style=(\"[^\"]*\"|'[^']*')",
+        r"(<span[^>]*class=['\"]editable['\"][^>]*?)\s+style=(\"[^\"]*\"|'[^']*')",
         r"\1",
         html_text,
         flags=re.IGNORECASE,

--- a/tests/test_inline_edit.py
+++ b/tests/test_inline_edit.py
@@ -5,13 +5,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from helpers import anchor, strip_anchors
 
-def test_anchor_produces_link_with_href():
+
+def test_anchor_produces_editable_span():
     html = anchor("Texto", "edit_field")
-    assert html.startswith("<a ")
-    assert 'href="edit_field"' in html
+    assert html.startswith("<span")
+    assert 'contenteditable="true"' in html
+    assert 'data-key="edit_field"' in html
 
 
-def test_strip_anchors_removes_link():
+def test_strip_anchors_removes_wrapper():
     html = anchor("Texto", "edit_field")
     stripped = strip_anchors(html)
     assert stripped == "Texto"


### PR DESCRIPTION
## Summary
- Remove dialog popups and anchor links, replacing them with inline editable spans wired to Streamlit session state.
- Update helper utilities to create and strip these editable spans instead of anchor tags.
- Adapt tests to reflect new inline editing behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894851f8d988322a1703c9ec9283c9c