### PR TITLE
Remove brackets from anchors

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -13,7 +13,7 @@ def dialog_link(texto: str, clave: str, placeholder: str | None = None) -> str:
     """
 
     if not texto.strip():
-        texto = placeholder or f"[{clave}]"
+        texto = placeholder or clave
     safe = html.escape(texto).replace("\n", "<br/>")
     style = "color:blue;"
     return (

--- a/tests/test_inline_edit.py
+++ b/tests/test_inline_edit.py
@@ -17,3 +17,16 @@ def test_strip_anchors_removes_wrapper():
     html = anchor("Texto", "edit_field")
     stripped = strip_anchors(html)
     assert stripped == "Texto"
+
+
+def test_anchor_without_text_uses_key_without_brackets_and_is_blue():
+    html = anchor("", "edit_field")
+    assert 'style="color:blue;"' in html
+    assert ">edit_field<" in html
+    assert "[" not in html and "]" not in html
+
+
+def test_anchor_with_placeholder_shows_placeholder_without_brackets():
+    html = anchor("", "edit_field", "Nombre")
+    assert ">Nombre<" in html
+    assert "[" not in html and "]" not in html


### PR DESCRIPTION
## Summary
- Remove square brackets from empty anchor placeholders while keeping the blue style
- Add tests to ensure anchors fall back to key or placeholder without brackets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689487c945388322936e8d399169c4f8