### PR TITLE
Handle missing OpenAI API key gracefully

### DIFF
--- a/app.py
+++ b/app.py
@@ -181,11 +181,15 @@ with st.sidebar:
         if up is None:
             st.warning("Subí un archivo primero.")
         else:
-            autocompletar(up.read(), up.name)
-            st.success(
-                "Campos cargados. Revisá y editá donde sea necesario."
-            )
-            st.rerun()   # refrescamos la UI
+            try:
+                autocompletar(up.read(), up.name)
+            except RuntimeError as exc:
+                st.error(str(exc))
+            else:
+                st.success(
+                    "Campos cargados. Revisá y editá donde sea necesario."
+                )
+                st.rerun()   # refrescamos la UI
 
 # ───────── pestañas de imputados (en la sidebar) ────────────────────
     for i in range(st.session_state.n_imputados):

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-  "api_key": "TU_API_KEY",
+  "api_key": "",
   "proxy": "http://usuario:contraseña@host:puerto"
 }

--- a/core.py
+++ b/core.py
@@ -47,11 +47,15 @@ _cfg = _cargar_config()
 
 def _get_openai_client():
     """Return an OpenAI client compatible with v0 and v1 APIs."""
-    api_key = os.environ.get("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", _cfg.get("api_key", ""))
+    api_key = os.environ.get("OPENAI_API_KEY", _cfg.get("api_key", ""))
+    if not api_key or api_key == "TU_API_KEY":
+        raise RuntimeError(
+            "Falta la clave de API de OpenAI. Definí OPENAI_API_KEY o actualizá config.json."
+        )
     proxy = os.environ.get("PROXY_URL", _cfg.get("proxy", ""))
     try:
         from openai import OpenAI  # type: ignore
-        kwargs = {"api_key": api_key} if api_key else {}
+        kwargs = {"api_key": api_key}
         if proxy:
             try:
                 import httpx  # type: ignore

--- a/ospro.py
+++ b/ospro.py
@@ -88,10 +88,14 @@ PROXY_URL_DEFAULT = _CONFIG.get("proxy", "")
 def _get_openai_client():
     """Return an OpenAI client for both old and new SDKs."""
     api_key = os.environ.get("OPENAI_API_KEY", OPENAI_API_KEY_DEFAULT)
+    if not api_key:
+        raise RuntimeError(
+            "Falta la clave de API de OpenAI. Definí OPENAI_API_KEY o actualizá config.json."
+        )
     proxy = PROXY_URL_DEFAULT
     try:
         from openai import OpenAI  # type: ignore
-        kwargs = {"api_key": api_key} if api_key else {}
+        kwargs = {"api_key": api_key}
         if proxy:
             try:
                 import httpx  # type: ignore


### PR DESCRIPTION
## Summary
- remove placeholder API key and read from `OPENAI_API_KEY` env var
- provide clear runtime error when API key missing
- surface configuration error in Streamlit app instead of stack trace

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689489e0a554832283e212b8ba2adca5