### PR TITLE
Sync editable spans with input fields

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -17,8 +17,8 @@ def dialog_link(texto: str, clave: str, placeholder: str | None = None) -> str:
     safe = html.escape(texto).replace("\n", "<br/>")
     style = "color:blue;"
     return (
-        f'<span class="editable" data-key="{clave}" contenteditable="true" '
-        f'style="{style}">{safe}</span>'
+        f'<span class="editable" data-key="{clave}" data-target="{clave}" '
+        f'contenteditable="true" style="{style}">{safe}</span>'
     )
 
 
@@ -34,8 +34,8 @@ def dialog_link_html(html_text: str, clave: str, placeholder: str | None = None)
     style_str = "".join(style)
     safe = html_text.replace("\n", "<br/>")
     return (
-        f'<span class="editable" data-key="{clave}" contenteditable="true" '
-        f'style="{style_str}">{safe}</span>'
+        f'<span class="editable" data-key="{clave}" data-target="{clave}" '
+        f'contenteditable="true" style="{style_str}">{safe}</span>'
     )
 
 

--- a/inline_edit.js
+++ b/inline_edit.js
@@ -1,0 +1,9 @@
+// Sync editable anchors with their corresponding inputs
+if (typeof document !== 'undefined') {
+  document.querySelectorAll('[contenteditable][data-target]').forEach(el => {
+    el.addEventListener('blur', () => {
+      const campo = document.getElementById(el.dataset.target);
+      if (campo) campo.value = el.innerText.trim();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- include `data-target` attribute on editable spans for field synchronization
- add frontend script to copy edited span text into matching input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68948920aec483228ce3649e7eff0601