### PR TITLE
Add OpenAI chat endpoint

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,5 +1,7 @@
 # api.py
 from fastapi import FastAPI, UploadFile, File, HTTPException
+from pydantic import BaseModel
+from typing import List
 import core
 
 app = FastAPI(title="Generador OSPRO")
@@ -11,4 +13,29 @@ async def autocompletar(file: UploadFile = File(...)):
         return datos
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    messages: List[Message]
+
+
+@app.post("/chat")
+async def chat(req: ChatRequest):
+    client = core._get_openai_client()
+    kwargs = {"model": "gpt-4o-mini", "messages": [m.model_dump() for m in req.messages]}
+    if hasattr(client, "chat"):
+        rsp = client.chat.completions.create(**kwargs)  # type: ignore[attr-defined]
+        if hasattr(rsp, "model_dump"):
+            return rsp.model_dump()
+        return rsp
+    else:
+        rsp = client.ChatCompletion.create(**kwargs)  # type: ignore[attr-defined]
+        if hasattr(rsp, "to_dict"):
+            return rsp.to_dict()
+        return rsp
 

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -1,0 +1,28 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure project root is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import api
+import core
+from fastapi.testclient import TestClient
+
+
+def test_chat_endpoint_returns_openai_response(monkeypatch):
+    class MockResponse:
+        def model_dump(self):
+            return {"choices": [{"message": {"content": "Hola"}}]}
+
+    class MockClient:
+        def __init__(self):
+            completions = types.SimpleNamespace(create=lambda **kwargs: MockResponse())
+            self.chat = types.SimpleNamespace(completions=completions)
+
+    monkeypatch.setattr(core, "_get_openai_client", lambda: MockClient())
+
+    client = TestClient(api.app)
+    resp = client.post("/chat", json={"messages": [{"role": "user", "content": "Hola"}]})
+    assert resp.status_code == 200
+    assert resp.json() == {"choices": [{"message": {"content": "Hola"}}]}


### PR DESCRIPTION
## Summary
- add `/chat` endpoint using FastAPI that proxies messages to OpenAI
- include Pydantic models for chat payloads
- add tests covering the new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_68948c35cad0832293212befcc2a657a