### PR TITLE
Fix anchor-entry sync using event delegation

### DIFF
--- a/inline_edit.js
+++ b/inline_edit.js
@@ -1,9 +1,13 @@
 // Sync editable anchors with their corresponding inputs
 if (typeof document !== 'undefined') {
-  document.querySelectorAll('[contenteditable][data-target]').forEach(el => {
-    el.addEventListener('blur', () => {
+  document.addEventListener(
+    'blur',
+    (ev) => {
+      const el = ev.target.closest('[contenteditable][data-target]');
+      if (!el) return;
       const campo = document.getElementById(el.dataset.target);
       if (campo) campo.value = el.innerText.trim();
-    });
-  });
+    },
+    true,
+  );
 }

--- a/tests/test_anchor_sync.py
+++ b/tests/test_anchor_sync.py
@@ -1,0 +1,34 @@
+import pytest
+from pathlib import Path
+
+pytest.importorskip('playwright.sync_api')
+from playwright.sync_api import sync_playwright
+
+
+def test_anchor_updates_input_when_blurred():
+    js = Path(__file__).resolve().parents[1] / 'inline_edit.js'
+    script = js.read_text()
+    html = f"""<!DOCTYPE html><html><body>
+    <input id='campo' value=''>
+    <div id='container'></div>
+    <script>{script}</script>
+    <script>
+    const span = document.createElement('span');
+    span.setAttribute('contenteditable','true');
+    span.dataset.target = 'campo';
+    document.getElementById('container').appendChild(span);
+    </script>
+    </body></html>"""
+    with sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception:
+            pytest.skip('chromium not available')
+        page = browser.new_page()
+        page.set_content(html)
+        span = page.locator('[contenteditable]')
+        span.fill('nuevo')
+        span.evaluate('el => el.blur()')
+        value = page.eval_on_selector('#campo', 'el => el.value')
+        browser.close()
+    assert value == 'nuevo'


### PR DESCRIPTION
## Summary
- ensure editable anchors propagate changes to matching inputs using a delegated blur listener
- add a Playwright-based test for anchor-input synchronization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68948e44213483228464720b3f69782e