### PR TITLE
feat: commit anchor edits with keyboard

### DIFF
--- a/inline_edit.js
+++ b/inline_edit.js
@@ -1,12 +1,31 @@
 // Sync editable anchors with their corresponding inputs
 if (typeof document !== 'undefined') {
+  const sync = (el) => {
+    const campo = document.getElementById(el.dataset.target);
+    if (campo) campo.value = el.innerText.trim();
+  };
+
+  // Update when the element loses focus
   document.addEventListener(
     'blur',
     (ev) => {
       const el = ev.target.closest('[contenteditable][data-target]');
+      if (el) sync(el);
+    },
+    true,
+  );
+
+  // Commit edits with Ctrl+Enter (or Cmd+Enter)
+  document.addEventListener(
+    'keydown',
+    (ev) => {
+      const el = ev.target.closest('[contenteditable][data-target]');
       if (!el) return;
-      const campo = document.getElementById(el.dataset.target);
-      if (campo) campo.value = el.innerText.trim();
+      if (ev.key === 'Enter' && (ev.ctrlKey || ev.metaKey)) {
+        ev.preventDefault();
+        sync(el);
+        el.blur();
+      }
     },
     true,
   );

--- a/tests/test_anchor_sync.py
+++ b/tests/test_anchor_sync.py
@@ -32,3 +32,32 @@ def test_anchor_updates_input_when_blurred():
         value = page.eval_on_selector('#campo', 'el => el.value')
         browser.close()
     assert value == 'nuevo'
+
+
+def test_anchor_updates_input_with_ctrl_enter():
+    js = Path(__file__).resolve().parents[1] / 'inline_edit.js'
+    script = js.read_text()
+    html = f"""<!DOCTYPE html><html><body>
+    <input id='campo' value=''>
+    <div id='container'></div>
+    <script>{script}</script>
+    <script>
+    const span = document.createElement('span');
+    span.setAttribute('contenteditable','true');
+    span.dataset.target = 'campo';
+    document.getElementById('container').appendChild(span);
+    </script>
+    </body></html>"""
+    with sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception:
+            pytest.skip('chromium not available')
+        page = browser.new_page()
+        page.set_content(html)
+        span = page.locator('[contenteditable]')
+        span.fill('nuevo')
+        span.press('Control+Enter')
+        value = page.eval_on_selector('#campo', 'el => el.value')
+        browser.close()
+    assert value == 'nuevo'


### PR DESCRIPTION
## Summary
- allow anchors to sync to the corresponding sidebar entry when blurred or when Ctrl+Enter is pressed
- test anchor syncing on blur and Ctrl+Enter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest tests/test_anchor_sync.py tests/test_inline_edit.py tests/test_resuelvo.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68949005391c8322ad6d99e87350a1d1