### PR TITLE
Fix firmantes type handling

### DIFF
--- a/core.py
+++ b/core.py
@@ -241,7 +241,12 @@ def autocompletar(file_bytes: bytes, filename: str) -> None:
     st.session_state.snum     = g.get("sent_num", "")
     st.session_state.sfecha   = g.get("sent_fecha", "")
     st.session_state.sres     = g.get("resuelvo", "")
-    st.session_state.sfirmaza = g.get("firmantes", [])
+    firmantes = g.get("firmantes") or ""
+    if isinstance(firmantes, list):
+        firmantes = ", ".join(str(f) for f in firmantes)
+    else:
+        firmantes = str(firmantes)
+    st.session_state.sfirmaza = firmantes
 
     # ----- IMPUTADOS -----
     imps = datos.get("imputados", [])

--- a/tests/test_autocompletar_firmantes.py
+++ b/tests/test_autocompletar_firmantes.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+pytest.importorskip("streamlit")
+
+import streamlit as st
+import core
+
+
+def test_autocompletar_converts_firmantes_to_string(monkeypatch):
+    st.session_state.clear()
+
+    def fake_procesar_sentencia(_bytes, _name):
+        return {
+            "generales": {"firmantes": ["Juez", "Secretario"]},
+            "imputados": [],
+        }
+
+    monkeypatch.setattr(core, "procesar_sentencia", fake_procesar_sentencia)
+
+    core.autocompletar(b"", "dummy.pdf")
+
+    assert st.session_state.sfirmaza == "Juez, Secretario"


### PR DESCRIPTION
## Summary
- Ensure `firmantes` field is stored as a string in session state
- Add regression test for autocompletar firmantes conversion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_b_68948fc3be3483229fcd27fee58f200e