### PR TITLE
Format autocompleted text

### DIFF
--- a/tests/test_autocompletar_firmantes.py
+++ b/tests/test_autocompletar_firmantes.py
@@ -24,3 +24,24 @@ def test_autocompletar_converts_firmantes_to_string(monkeypatch):
     core.autocompletar(b"", "dummy.pdf")
 
     assert st.session_state.sfirmaza == "Juez, Secretario"
+
+
+def test_autocompletar_handles_dict_firmantes(monkeypatch):
+    st.session_state.clear()
+
+    def fake_procesar_sentencia(_bytes, _name):
+        return {
+            "generales": {
+                "firmantes": [
+                    {"nombre": "Ana Perez", "cargo": "Jueza"},
+                    {"nombre": "Luis Gomez", "cargo": "Secretario"},
+                ]
+            },
+            "imputados": [],
+        }
+
+    monkeypatch.setattr(core, "procesar_sentencia", fake_procesar_sentencia)
+
+    core.autocompletar(b"", "dummy.pdf")
+
+    assert st.session_state.sfirmaza == "Ana Perez, Jueza; Luis Gomez, Secretario"

--- a/tests/test_autocompletar_resuelvo_datos.py
+++ b/tests/test_autocompletar_resuelvo_datos.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+pytest.importorskip("streamlit")
+
+import streamlit as st
+import core
+
+
+def test_autocompletar_formats_resuelvo_and_datos(monkeypatch):
+    st.session_state.clear()
+
+    def fake_procesar_sentencia(_bytes, _name):
+        return {
+            "generales": {"resuelvo": ["Punto 1", "Punto 2"]},
+            "imputados": [
+                {"datos_personales": {"nombre": "Juan Perez", "dni": "12.345"}}
+            ],
+        }
+
+    monkeypatch.setattr(core, "procesar_sentencia", fake_procesar_sentencia)
+
+    core.autocompletar(b"", "dummy.pdf")
+
+    assert st.session_state.sres == "Punto 1, Punto 2"
+    assert st.session_state.imp0_datos == "Juan Perez, D.N.I. 12.345"


### PR DESCRIPTION
## Summary
- normalize lists and dicts into plain strings for web autocompletion
- reuse desktop formatting for resuelvo and personal data in the Streamlit UI
- cover firmantes/resuelvo formatting with tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_b_6894929f8a108322a87597e248334c6e