### PR TITLE
Fix Streamlit copy button to always copy text

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 # app.py  – versión resumida
+import json
 import streamlit as st
 import streamlit.components.v1 as components
 from core import autocompletar   # ← función principal
@@ -12,15 +13,28 @@ def copy_to_clipboard(texto: str) -> None:
     En versiones recientes de Streamlit el helper experimental
     ``st.experimental_copy`` fue removido.  Para mantener la
     funcionalidad se intenta utilizar :mod:`pyperclip` y, en caso de
-    no estar disponible, se muestra el texto para copiarlo de forma
-    manual.
+    no estar disponible, se recurre a la API del navegador.
     """
     try:
         import pyperclip  # type: ignore
 
         pyperclip.copy(texto)
         st.success("Texto copiado al portapapeles")
+        return
     except Exception:  # pragma: no cover - solo en entornos sin pyperclip
+        pass
+
+    try:
+        components.html(
+            f"""
+            <script>
+            navigator.clipboard.writeText({json.dumps(texto)});
+            </script>
+            """,
+            height=0,
+        )
+        st.success("Texto copiado al portapapeles")
+    except Exception:  # pragma: no cover - sin soporte de portapapeles
         st.code(texto)
         st.warning("No se pudo copiar automáticamente. Copie el texto manualmente.")
 


### PR DESCRIPTION
## Summary
- Use `navigator.clipboard.writeText` fallback when `pyperclip` is unavailable

## Testing
- `python -m py_compile app.py`
- `pytest tests/test_api_chat.py::test_api_dummy -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_b_68949ed6bde083228687e3d0349b434e