### PR TITLE
Improve caratula extraction for SAC text

### DIFF
--- a/core.py
+++ b/core.py
@@ -109,8 +109,10 @@ def limpiar_pies_de_pagina(texto: str) -> str:
 limpiar_pies = limpiar_pies_de_pagina
 
 # ── CARÁTULA ──────────────────────────────────────────────────────────
-_PAT_CARAT_1 = re.compile(          # 1) bloque completo con comillas
-    r'([^“\n]+?“[^”]+?”)\s*\(\s*(?:Expte\.\s*)?(?:SAC|Expte\.?)\s*(?:N°)?\s*([\d.]+)\s*\)',
+_PAT_CARAT_1 = re.compile(          # 1) bloque completo con o sin paréntesis
+    r'([^"\n]*?["“][^"”]+?["”])\s*'
+    r'(?:\(\s*(?:Expte\.\s*)?(?:SAC|Expte\.?)\s*(?:N\s*[°º\.]*\s*)?([\d.]+)\s*\)'
+    r'|(?:Expte\.\s*)?(?:SAC|Expte\.?)\s*(?:N\s*[°º\.]*\s*)?([\d.]+))',
     re.I,
 )
 
@@ -134,7 +136,11 @@ def extraer_caratula(txt: str) -> str:
 
     m = _PAT_CARAT_1.search(plano)
     if m:
-        bloque, nro = m.groups()
+        bloque, n1, n2 = m.groups()
+        nro = n1 or n2
+        bloque = bloque.strip()
+        if bloque.startswith(('"', '“')) and bloque.endswith(('"', '”')):
+            bloque = bloque[1:-1]
         return f'{bloque.strip()} (SAC N° {nro})'
 
     m = _PAT_CARAT_2.search(plano)

--- a/ospro.py
+++ b/ospro.py
@@ -392,8 +392,11 @@ def limpiar_pies_de_pagina(texto: str) -> str:
     return re.sub(_FOOTER_REGEX, " ", texto)
 
 # ── CARÁTULA ──────────────────────────────────────────────────────────
-_PAT_CARAT_1 = re.compile(          # 1) entre comillas
-    r'“([^”]+?)”\s*\(\s*(?:SAC|Expte\.?)\s*N°?\s*([\d.]+)\s*\)', re.I)
+_PAT_CARAT_1 = re.compile(          # 1) bloque completo con o sin paréntesis
+    r'([^"\n]*?["“][^"”]+?["”])\s*'
+    r'(?:\(\s*(?:SAC|Expte\.?)\s*(?:N\s*[°º\.]*\s*)?([\d.]+)\s*\)'
+    r'|(?:SAC|Expte\.?)\s*(?:N\s*[°º\.]*\s*)?([\d.]+))',
+    re.I)
 
 _PAT_CARAT_2 = re.compile(          # 2) autos caratulados “…”
     r'autos?\s+(?:se\s+)?(?:denominad[oa]s?|intitulad[oa]s?|'
@@ -415,8 +418,12 @@ def extraer_caratula(txt: str) -> str:
 
     m = _PAT_CARAT_1.search(plano)
     if m:
-        titulo, nro = m.groups()
-        return f'“{titulo.strip()}” (SAC N° {nro})'
+        bloque, n1, n2 = m.groups()
+        nro = n1 or n2
+        bloque = bloque.strip()
+        if bloque.startswith(('"', '“')) and bloque.endswith(('"', '”')):
+            bloque = bloque[1:-1]
+        return f'{bloque.strip()} (SAC N° {nro})'
 
     m = _PAT_CARAT_2.search(plano)
     if m:

--- a/tests/test_caratula.py
+++ b/tests/test_caratula.py
@@ -22,3 +22,15 @@ def test_extraer_caratula_expte_sac():
     texto = 'Leiva David p. s. a. de “robo en grado de tentativa” (Expte. Sac 13250038)'
     esperado = 'Leiva David p. s. a. de “robo en grado de tentativa” (SAC N° 13250038)'
     assert core.extraer_caratula(texto) == esperado
+
+
+def test_extraer_caratula_sin_parentesis():
+    texto = (
+        '"Agüero, Saúl Maximiliano y otro p.ss.aa robo calificado por escalamiento, etc." '
+        'SAC n.° 13551621, radicados por ante este Juzgado...'
+    )
+    esperado = (
+        'Agüero, Saúl Maximiliano y otro p.ss.aa robo calificado por escalamiento, etc. '
+        '(SAC N° 13551621)'
+    )
+    assert core.extraer_caratula(texto) == esperado


### PR DESCRIPTION
## Summary
- handle carátulas where the SAC number appears without parentheses
- strip surrounding quotes and support variants like "SAC n.º" in both core and ospro helpers
- add regression test for carátula extraction without parentheses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894a323a9588322b677b586a5ea0bcb