### PR TITLE
Improve carátula autocompletion parsing

### DIFF
--- a/core.py
+++ b/core.py
@@ -139,6 +139,14 @@ def extraer_caratula(txt: str) -> str:
         bloque, n1, n2 = m.groups()
         nro = n1 or n2
         bloque = bloque.strip()
+        mq = re.search(r'["“][^"”]+["”]', bloque)
+        if mq:
+            quoted = mq.group(0)
+            prefix = bloque[:mq.start()].strip()
+            if prefix and len(prefix) <= 80:
+                bloque = f'{prefix} {quoted}'
+            else:
+                bloque = quoted
         if bloque.startswith(('"', '“')) and bloque.endswith(('"', '”')):
             bloque = bloque[1:-1]
         return f'{bloque.strip()} (SAC N° {nro})'

--- a/ospro.py
+++ b/ospro.py
@@ -421,6 +421,14 @@ def extraer_caratula(txt: str) -> str:
         bloque, n1, n2 = m.groups()
         nro = n1 or n2
         bloque = bloque.strip()
+        mq = re.search(r'["“][^"”]+["”]', bloque)
+        if mq:
+            quoted = mq.group(0)
+            prefix = bloque[:mq.start()].strip()
+            if prefix and len(prefix) <= 80:
+                bloque = f'{prefix} {quoted}'
+            else:
+                bloque = quoted
         if bloque.startswith(('"', '“')) and bloque.endswith(('"', '”')):
             bloque = bloque[1:-1]
         return f'{bloque.strip()} (SAC N° {nro})'

--- a/tests/test_caratula.py
+++ b/tests/test_caratula.py
@@ -34,3 +34,19 @@ def test_extraer_caratula_sin_parentesis():
         '(SAC N° 13551621)'
     )
     assert core.extraer_caratula(texto) == esperado
+
+
+def test_extraer_caratula_con_texto_previo():
+    texto = (
+        'JUZGADO DE CONTROL Y FALTAS Nº 9 Protocolo de Sentencias Nº Resolución: 5 Año: 2025 '
+        'Tomo: 1 Folio: 16-23 EXPEDIENTE SAC: 13393379 - DIAZ, ESTEBAN ARIEL - DIAZ, '
+        'YANINA ELIZABETH - CAUSA CON IMPUTADOS PROTOCOLO DE SENTENCIAS. NÚMERO: 5 DEL '
+        '12/02/2025 En la ciudad de Córdoba, el doce de febrero de dos mil veinticinco, se '
+        'dan a conocer los fundamentos de la sentencia dictada en la causa "Díaz, Esteban '
+        'Ariel y otra p. ss. aa. amenazas calificadas, etc." (SAC N° 13393379)'
+    )
+    esperado = (
+        'Díaz, Esteban Ariel y otra p. ss. aa. amenazas calificadas, etc. '
+        '(SAC N° 13393379)'
+    )
+    assert core.extraer_caratula(texto) == esperado


### PR DESCRIPTION
## Summary
- Refine carátula extraction by trimming long prefixes before quoted titles
- Apply same logic across CLI and GUI modules
- Add regression test for carátula with preceding header text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894a5fd70c48322a7c8eb8cbd4f694c