### PR TITLE
feat: auto-complete caratula via regex extraction

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 import streamlit.components.v1 as components
 import uuid, json, html as _html
-from core import autocompletar          # lógica de autocompletado
+from core import autocompletar, autocompletar_caratula  # lógica de autocompletado
 from helpers import dialog_link, strip_dialog_links
 from helpers import create_clipboard_html
 
@@ -211,7 +211,10 @@ def html_copy_button(label: str, html_fragment: str, *, key: str | None = None):
 with st.sidebar:
     st.header("Datos generales")
     loc       = st.text_input("Localidad", value="Córdoba", key="loc")
-    caratula  = st.text_input("Carátula", key="carat")
+    caratula_raw = st.text_input("Carátula", key="carat")
+    caratula = autocompletar_caratula(caratula_raw)
+    if caratula != caratula_raw:
+        st.session_state.carat = caratula
     tribunal  = st.text_input("Tribunal", key="trib")
 
     col1, col2 = st.columns(2)

--- a/core.py
+++ b/core.py
@@ -329,6 +329,15 @@ def normalizar_caratula(txt: str) -> str:
     return txt
 
 
+def autocompletar_caratula(txt: str) -> str:
+    """Intenta extraer y normalizar la carátula desde ``txt``."""
+    txt = normalizar_caratula(txt)
+    if not txt:
+        return ""
+    extraida = extraer_caratula(txt)
+    return extraida or txt
+
+
 def normalizar_dni(txt: str) -> str:
     """Devuelve solo los dígitos del DNI."""
     if txt is None:
@@ -545,7 +554,7 @@ def autocompletar(file_bytes: bytes, filename: str) -> None:
 
 
 # ────────────────── API pública ─────────────────────────────
-__all__ = ["autocompletar"]
+__all__ = ["autocompletar", "autocompletar_caratula"]
 
 
 if __name__ == "__main__":

--- a/ospro.py
+++ b/ospro.py
@@ -609,6 +609,15 @@ def normalizar_caratula(txt: str) -> str:
     return txt
 
 
+def autocompletar_caratula(txt: str) -> str:
+    """Intenta extraer y normalizar la carátula desde ``txt``."""
+    txt = normalizar_caratula(txt)
+    if not txt:
+        return ""
+    extraida = extraer_caratula(txt)
+    return extraida or txt
+
+
 def normalizar_dni(txt: str) -> str:
     """Devuelve solo los dígitos del DNI."""
     if txt is None:
@@ -2413,7 +2422,7 @@ class MainWindow(QMainWindow):
 
     def _check_caratula(self) -> None:
         """Valida el formato de la carátula al finalizar la edición."""
-        txt = normalizar_caratula(self.entry_caratula.text())
+        txt = autocompletar_caratula(self.entry_caratula.text())
         self.entry_caratula.setText(txt)
         if txt and not CARATULA_REGEX.match(txt):
             QMessageBox.warning(

--- a/tests/test_caratula.py
+++ b/tests/test_caratula.py
@@ -101,3 +101,24 @@ def test_extraer_caratula_con_texto_previo():
         '(SAC N° 13393379)'
     )
     assert core.extraer_caratula(texto) == esperado
+
+
+def test_autocompletar_caratula_no_modifica_valida():
+    carat = 'Leiva David p. s. a. de robo en grado de tentativa (SAC N° 13250038)'
+    assert core.autocompletar_caratula(carat) == carat
+
+
+def test_autocompletar_caratula_extrae_del_texto():
+    texto = (
+        'JUZGADO DE CONTROL Y FALTAS Nº 9 Protocolo de Sentencias Nº Resolución: 5 Año: 2025 '
+        'Tomo: 1 Folio: 16-23 EXPEDIENTE SAC: 13393379 - DIAZ, ESTEBAN ARIEL - DIAZ, '
+        'YANINA ELIZABETH - CAUSA CON IMPUTADOS PROTOCOLO DE SENTENCIAS. NÚMERO: 5 DEL '
+        '12/02/2025 En la ciudad de Córdoba, el doce de febrero de dos mil veinticinco, se '
+        'dan a conocer los fundamentos de la sentencia dictada en la causa "Díaz, Esteban '
+        'Ariel y otra p. ss. aa. amenazas calificadas, etc." (SAC N° 13393379)'
+    )
+    esperado = (
+        'Díaz, Esteban Ariel y otra p. ss. aa. amenazas calificadas, etc. '
+        '(SAC N° 13393379)'
+    )
+    assert core.autocompletar_caratula(texto) == esperado


### PR DESCRIPTION
## Summary
- add `autocompletar_caratula` helper to parse and normalize captions
- wire carátula autocompletion into Streamlit and Qt GUIs
- cover carátula autocompletion with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894bebbceec8322b71140dc36bbb574