### PR TITLE
Fix carátula quoting behavior

### DIFF
--- a/core.py
+++ b/core.py
@@ -148,8 +148,6 @@ def extraer_caratula(txt: str) -> str:
                 bloque = f'{prefix} {quoted}'
             else:
                 bloque = quoted
-        if bloque.startswith(('"', '“')) and bloque.endswith(('"', '”')):
-            bloque = bloque[1:-1]
         return f'{bloque.strip()} (SAC N° {nro})'
 
     m = _PAT_CARAT_2.search(plano)
@@ -320,12 +318,20 @@ def capitalizar_frase(txt: str) -> str:
 
 
 def normalizar_caratula(txt: str) -> str:
-    """Reemplaza comillas simples por dobles y normaliza espacios."""
+    """Reemplaza comillas simples por dobles, balancea y normaliza espacios."""
     if txt is None:
         return ""
     txt = txt.strip()
+    # unifico variantes de comillas en una sola
     txt = txt.replace("\u201c", '"').replace("\u201d", '"')
     txt = txt.replace("'", '"')
+    # si hay una sola comilla, cierro antes del número de expediente/SAC
+    if txt.count('"') == 1:
+        m = re.search(r'\s*(\(\s*(?:Expte\.\s*)?(?:SAC|Expte\.?)\b)', txt, re.I)
+        if m:
+            txt = txt[:m.start()].rstrip() + '"' + txt[m.start():]
+        else:
+            txt = txt + '"'
     return txt
 
 

--- a/tests/test_caratula.py
+++ b/tests/test_caratula.py
@@ -81,7 +81,7 @@ def test_extraer_caratula_sin_parentesis():
         'SAC n.° 13551621, radicados por ante este Juzgado...'
     )
     esperado = (
-        'Agüero, Saúl Maximiliano y otro p.ss.aa robo calificado por escalamiento, etc. '
+        '“Agüero, Saúl Maximiliano y otro p.ss.aa robo calificado por escalamiento, etc.” '
         '(SAC N° 13551621)'
     )
     assert core.extraer_caratula(texto) == esperado
@@ -97,7 +97,7 @@ def test_extraer_caratula_con_texto_previo():
         'Ariel y otra p. ss. aa. amenazas calificadas, etc." (SAC N° 13393379)'
     )
     esperado = (
-        'Díaz, Esteban Ariel y otra p. ss. aa. amenazas calificadas, etc. '
+        '“Díaz, Esteban Ariel y otra p. ss. aa. amenazas calificadas, etc.” '
         '(SAC N° 13393379)'
     )
     assert core.extraer_caratula(texto) == esperado
@@ -118,7 +118,7 @@ def test_autocompletar_caratula_extrae_del_texto():
         'Ariel y otra p. ss. aa. amenazas calificadas, etc." (SAC N° 13393379)'
     )
     esperado = (
-        'Díaz, Esteban Ariel y otra p. ss. aa. amenazas calificadas, etc. '
+        '“Díaz, Esteban Ariel y otra p. ss. aa. amenazas calificadas, etc.” '
         '(SAC N° 13393379)'
     )
     assert core.autocompletar_caratula(texto) == esperado


### PR DESCRIPTION
## Summary
- Balance and normalize quote characters when autocompleting carátulas
- Preserve existing quotes in extracted carátulas and adjust tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894c2f4c43483229492e2a741e63276