### PR TITLE
Add placeholder ellipsis and Ctrl+Enter sync for anchors

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -2,22 +2,28 @@
 import html
 import re
 
-def dialog_link(texto: str, key: str, *, bold: bool = False) -> str:
-    """
-    Envuelve texto en un <span> editable que refleja automáticamente
-    su contenido en st.session_state[key].
+def dialog_link(texto: str, key: str, placeholder: str | None = None, *, bold: bool = False) -> str:
+    """Return an editable HTML span linked to ``key``.
 
-    • key        → nombre exacto del widget/clave en session_state  
-    • bold=True  → mantiene el <b> que usás en algunos llamados
+    ``texto`` es el contenido inicial.  Si está vacío, se mostrará
+    ``placeholder`` (o puntos suspensivos si tampoco se provee un
+    placeholder).  El ``key`` se replica en los atributos ``data-key`` y
+    ``data-target`` para que ``inline_edit.js`` pueda sincronizar el valor
+    con el campo correspondiente cuando el usuario presiona ``Ctrl+Enter``
+    o el elemento pierde el foco.
     """
-    safe = html.escape(texto or "")
+
+    contenido = texto.strip()
+    if not contenido:
+        contenido = placeholder if placeholder is not None else "…"
+
+    safe = html.escape(contenido)
     span = (
-        f"<span contenteditable='true' "
-        f"       spellcheck='false' "
-        f"       class='editable' "
-        f"       style='color:#0068c9;text-decoration:underline;cursor:pointer;' "
-        f"       data-key='{key}'>"      # ← ***importantísimo***
-        f"{safe}</span>"
+        f'<span contenteditable="true" '
+        f'spellcheck="false" '
+        f'class="editable" '
+        f'style="color:blue;" '
+        f'data-key="{key}" data-target="{key}">{safe}</span>'
     )
     return f"<b>{span}</b>" if bold else span
 

--- a/tests/test_inline_edit.py
+++ b/tests/test_inline_edit.py
@@ -19,10 +19,10 @@ def test_strip_anchors_removes_wrapper():
     assert stripped == "Texto"
 
 
-def test_anchor_without_text_uses_key_without_brackets_and_is_blue():
+def test_anchor_without_text_shows_ellipsis_and_is_blue():
     html = anchor("", "edit_field")
     assert 'style="color:blue;"' in html
-    assert ">edit_field<" in html
+    assert ">…<" in html
     assert "[" not in html and "]" not in html
 
 


### PR DESCRIPTION
## Summary
- Show ellipsis placeholder when anchor text is empty
- Sync editable anchors to matching inputs via `data-target`
- Update tests for ellipsis placeholder behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894c94048508322b4c7c15135355a6f