### PR TITLE
Add editable comboboxes for legal field inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,14 @@ from datetime import datetime
 
 import streamlit as st
 import streamlit.components.v1 as components
-from core import autocompletar, autocompletar_caratula  # lógica de autocompletado
+from core import (
+    autocompletar,
+    autocompletar_caratula,
+    PENITENCIARIOS,
+    DEPOSITOS,
+    JUZ_NAVFYG,
+    TRIBUNALES,
+)  # lógica de autocompletado y listas
 from helpers import dialog_link, strip_dialog_links, create_clipboard_html
 
 # ────────── util: copiar al portapapeles ────────────────────────────
@@ -108,6 +115,16 @@ def _html_compat(content: str, *, height: int = 0, width: int = 0):
 
     # ≤ 1.29
     return components.html(content, height=height, width=width)
+
+
+# ────────── combos editables (selectbox + texto libre) ──────────────
+def combo_editable(label: str, opciones: list[str], *, key: str) -> str:
+    """Combobox que permite elegir de la lista o escribir un valor nuevo."""
+    actual = st.session_state.get(key, "")
+    opts = list(opciones)
+    if actual and actual not in opts:
+        opts.append(actual)
+    return st.selectbox(label, opts, key=key)
 
 
 # ────────── inyección global para spans editables ───────────────────
@@ -322,7 +339,7 @@ with st.sidebar:
     )
     caratula = st.session_state.carat     # ← reemplaza a tu caratula_raw
 
-    tribunal  = st.text_input("Tribunal", key="trib")
+    tribunal  = combo_editable("Tribunal", TRIBUNALES, key="trib")
 
     col1, col2 = st.columns(2)
     with col1:
@@ -334,6 +351,7 @@ with st.sidebar:
     resuelvo     = st.text_area("Resuelvo", height=80, key="sres")
     firmantes    = st.text_input("Firmantes", key="sfirmantes")  # Corregido key
     consulado    = st.text_input("Consulado", key="consulado")
+    deposito     = combo_editable("Depósito", DEPOSITOS, key="deposito")
 
     # Nº de imputados dinámico
     n = st.number_input(
@@ -367,13 +385,21 @@ with st.sidebar:
             st.text_input("Condena",           key=f"{k}_condena")
             st.text_area("Cómputo de pena", key=f"{k}_computo", height=80)
             st.selectbox("Tipo de cómputo", ["Efec.", "Cond."], key=f"{k}_computo_tipo")
-            st.text_input("Servicio Correccional o Penitenciario", key=f"{k}_servicio_penitenciario")
+            combo_editable(
+                "Servicio Correccional o Penitenciario",
+                PENITENCIARIOS,
+                key=f"{k}_servicio_penitenciario",
+            )
             st.text_input("Legajo", key=f"{k}_legajo")
             st.text_input("Delito (con el tipo de delito y la fecha)", key=f"{k}_delitos")
             st.text_input("Liberación (fecha y motivo)", key=f"{k}_liberacion")
             st.text_area("Historial de delitos y condenas anteriores", key=f"{k}_antecedentes", height=80)
             st.text_area("Tratamientos médicos y psicológicos", key=f"{k}_tratamientos", height=80)
-            st.text_input("Juzgado de Niñez, Adolescencia, V.F. y Género", key=f"{k}_juz_navfyg")
+            combo_editable(
+                "Juzgado de Niñez, Adolescencia, V.F. y Género",
+                JUZ_NAVFYG,
+                key=f"{k}_juz_navfyg",
+            )
             st.text_input("Expediente de V.F. relacionado", key=f"{k}_ee_relacionado")
 
 

--- a/core.py
+++ b/core.py
@@ -59,6 +59,79 @@ def _cargar_config() -> Dict[str, Any]:
 _cfg = _cargar_config()
 
 
+# ── listas de opciones para la UI web ───────────────────────────────
+PENITENCIARIOS = [
+    "Complejo Carcelario n.° 1 (Bouwer)",
+    "Establecimiento Penitenciario n.° 9 (UCA)",
+    "Establecimiento Penitenciario n.° 3 (para mujeres)",
+    "Complejo Carcelario n.° 2 (Cruz del Eje)",
+    "Establecimiento Penitenciario n.° 4 (Colonia Abierta Monte Cristo)",
+    "Establecimiento Penitenciario n.° 5 (Villa María)",
+    "Establecimiento Penitenciario n.° 6 (Río Cuarto)",
+    "Establecimiento Penitenciario n.° 7 (San Francisco)",
+    "Establecimiento Penitenciario n.° 8 (Villa Dolores)",
+]
+
+DEPOSITOS = [
+    "Depósito General de Efectos Secuestrados",
+    "Depósito de la Unidad Judicial de Lucha c/ Narcotráfico",
+    "Depósito de Armas (Tribunales II)",
+    "Depósito de Automotores 1 (Bouwer)",
+    "Depósito de Automotores 2 (Bouwer)",
+    "Depositado en Cuenta Judicial en pesos o dólares del Banco de Córdoba",
+    "Depósito de Armas y elementos secuestrados (Tribunales II)",
+]
+
+JUZ_NAVFYG = [
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 1ª Nom. – Sec.\u202fN°\u202f1",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 1ª Nom. – Sec.\u202fN°\u202f2",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 2ª Nom. – Sec.\u202fN°\u202f3",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 2ª Nom. – Sec.\u202fN°\u202f4",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 3ª Nom. – Sec.\u202fN°\u202f5",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 3ª Nom. – Sec.\u202fN°\u202f6",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 4ª Nom. – Sec.\u202fN°\u202f7",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 4ª Nom. – Sec.\u202fN°\u202f8",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 5ª Nom. – Sec.\u202fN°\u202f9",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 5ª Nom. – Sec.\u202fN°\u202f10",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 6ª Nom. – Sec.\u202fN°\u202f11",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 6ª Nom. – Sec.\u202fN°\u202f12",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 7ª Nom. – Sec.\u202fN°\u202f13",
+    "Juzgado de Niñez, Adolescencia, Violencia Familiar y de Género de 7ª Nom. – Sec.\u202fN°\u202f14",
+    "Juzgado de Violencia de Género, modalidad doméstica -causas graves- de 8ª Nom. – Sec.\u202fN°\u202f15",
+    "Juzgado de Violencia de Género, modalidad doméstica -causas graves- de 8ª Nom. – Sec.\u202fN°\u202f16",
+    "Juzgado de Violencia de Género, modalidad doméstica -causas graves- de 9ª Nom. – Sec.\u202fN°\u202f17",
+    "Juzgado de Violencia de Género, modalidad doméstica -causas graves- de 9ª Nom. – Sec.\u202fN°\u202f18",
+]
+
+TRIBUNALES = [
+    "la Cámara en lo Criminal y Correccional de Primera Nominación",
+    "la Cámara en lo Criminal y Correccional de Segunda Nominación",
+    "la Cámara en lo Criminal y Correccional de Tercera Nominación",
+    "la Cámara en lo Criminal y Correccional de Cuarta Nominación",
+    "la Cámara en lo Criminal y Correccional de Quinta Nominación",
+    "la Cámara en lo Criminal y Correccional de Sexta Nominación",
+    "la Cámara en lo Criminal y Correccional de Séptima Nominación",
+    "la Cámara en lo Criminal y Correccional de Octava Nominación",
+    "la Cámara en lo Criminal y Correccional de Novena Nominación",
+    "la Cámara en lo Criminal y Correccional de Décima Nominación",
+    "la Cámara en lo Criminal y Correccional de Onceava Nominación",
+    "la Cámara en lo Criminal y Correccional de Doceava Nominación",
+    "el Juzgado de Control en lo Penal Económico",
+    "el Juzgado de Control y Faltas N° 2",
+    "el Juzgado de Control y Faltas N° 3",
+    "el Juzgado de Control y Faltas N° 4",
+    "el Juzgado de Control y Faltas N° 5",
+    "el Juzgado de Control en Violencia de Género y Familiar N° 1",
+    "el Juzgado de Control en Violencia de Género y Familiar N° 2",
+    "el Juzgado de Control y Faltas N° 7",
+    "el Juzgado de Control y Faltas N° 8",
+    "el Juzgado de Control y Faltas N° 9",
+    "el Juzgado de Control y Faltas N° 10",
+    "el Juzgado de Control y Faltas N° 11",
+    "el Juzgado de Control de Lucha contra el Narcotráfico",
+]
+
+
 def _get_openai_client():
     """Return an OpenAI client compatible with v0 and v1 APIs."""
     api_key = os.environ.get("OPENAI_API_KEY", _cfg.get("api_key", ""))
@@ -590,7 +663,14 @@ def autocompletar(file_bytes: bytes, filename: str) -> None:
 
 
 # ────────────────── API pública ─────────────────────────────
-__all__ = ["autocompletar", "autocompletar_caratula"]
+__all__ = [
+    "autocompletar",
+    "autocompletar_caratula",
+    "PENITENCIARIOS",
+    "DEPOSITOS",
+    "JUZ_NAVFYG",
+    "TRIBUNALES",
+]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add predefined option lists for tribunals, detention centers and more
- use reusable `combo_editable` helper in web UI
- switch tribunal, penitentiary, Niñez court and deposit fields to editable comboboxes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b1b4ad94c83229965355705a17a8b