### PR TITLE
Añade scroll horizontal para pestañas de oficios

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,6 +84,15 @@ span.editable {
     text-decoration: none !important;
     cursor: pointer !important;
 }
+/* Scroll horizontal para los títulos de las pestañas de oficios */
+div[role="tablist"] {
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 8px;
+}
+div[role="tablist"]::-webkit-scrollbar {
+    height: 8px;
+}
 </style>
 """, unsafe_allow_html=True)
 


### PR DESCRIPTION
## Summary
- Muestra una barra de desplazamiento horizontal bajo los títulos de las pestañas de oficios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b2a514c7c8322bc3c81aa6b66074f