### PR TITLE
Restore ospro extraction behavior in core

### DIFF
--- a/core.py
+++ b/core.py
@@ -181,25 +181,39 @@ def limpiar_pies_de_pagina(texto: str) -> str:
 # alias histórico
 limpiar_pies = limpiar_pies_de_pagina
 
+# ­­­ ---- bloque RESUELVE / RESUELVO ───────────────────────────────
+_RESUELVO_REGEX = re.compile(
+    r"""
+    resuelv[eo]\s*:?\s*                           # “RESUELVE:” / “RESUELVO:”
+    (?P<bloque>                                   # ← bloque que queremos extraer
+        (?:
+            (?:                                   # ─ un inciso: I) / 1. / II.- …
+                \s*(?:[IVXLCDM]+|\d+)             #   núm. romano o arábigo
+                \s*(?:\)|\.-|\.|-|-)              #   )  .  -  -  o .-   ← ¡cambio!
+                \s+
+                .*?                               #   texto del inciso (lazy)
+                (?:                               #   líneas del mismo inciso
+                    \n(?!\s*(?:[IVXLCDM]+|\d+)\s*(?:\)|\.-|\.|-|-) ).*?
+                )*
+            )
+        )+                                        # uno o más incisos
+    )
+    (?=                                           # -- corte del bloque --
+        \s*(?:Protocol[íi]?cese|Notifíquese|
+            Hágase\s+saber|Of[íi]ciese)           # fórmulas de cierre
+        |\Z                                       # o fin de texto
+    )
+    """,
+    re.IGNORECASE | re.DOTALL | re.VERBOSE,
+)
+
 # ── CARÁTULA ──────────────────────────────────────────────────────────
-_PAT_CARAT_1 = re.compile(
-    r'(.+?)\s*'                                                      # todo antes de las comillas
-    r'(?:\(\s*(?:Expte\.\s*)?(?:SAC|Expte\.?)\s*'                    #  (Expte. SAC 123)
-    r'(?:N\s*[°º\.]*\s*)?([\d.]+)\s*\)'                              #     ↑ nº capturado
-    r'|(?:Expte\.\s*)?(?:SAC|Expte\.?)\s*'                           #  o “SAC 123” sin paréntesis
-    r'(?:N\s*[°º\.]*\s*)?([\d.]+))',                                 #     ↑ nº capturado
-    re.I,
-)
-# 2) “… autos caratulados Leiva … p. s. a. de “hecho” …”
-_PAT_CARAT_2 = re.compile(
-    r'autos?\s+(?:se\s+)?(?:denominad[oa]s?|intitulad[oa]s?|caratulad[oa]s?)\s+'  # disparador
-    r'('                                                                           # ← grupo 1: TODO el título
-        r'(?:[^"»\n]+?)\s*'                    #  - prefijo antes de las comillas
-        r'(?:[«"”][^"»\n]+[»"”])'              #  - “hecho” (con cualquier tipo de comillas)
-        r'(?:[^,;.()]*)'                       #  - y lo que siga hasta un separador
-    r')',
-    re.I,
-)
+_PAT_CARAT_1 = re.compile(          # 1) entre comillas
+    r'“([^”]+?)”\s*\(\s*(?:SAC|Expte\.?)\s*N°?\s*([\d.]+)\s*\)', re.I)
+
+_PAT_CARAT_2 = re.compile(          # 2) autos caratulados “…”
+    r'autos?\s+(?:se\s+)?(?:denominad[oa]s?|intitulad[oa]s?|'
+    r'caratulad[oa]s?)\s+[«"”]?([^"»\n]+)[»"”]?', re.I)
 
 _PAT_CARAT_3 = re.compile(          # 3) encabezado “EXPEDIENTE SAC: … - …”
     r'EXPEDIENTE\s+(?:SAC|Expte\.?)\s*:?\s*([\d.]+)\s*-\s*(.+?)(?:[-–]|$)', re.I)
@@ -217,23 +231,8 @@ def extraer_caratula(txt: str) -> str:
 
     m = _PAT_CARAT_1.search(plano)
     if m:
-        bloque, n1, n2 = m.groups()   # ← 3 grupos
-        nro = n1 or n2                # el que no sea None
-        #  normalizo comillas…
-        mq = re.search(r"[\"“'‘`][^\"”'’`]+[\"”'’`]", bloque)
-        if mq:
-            inner  = mq.group(0)[1:-1]
-            quoted = f'“{inner}”'
-            # Solo tomar la porción tras 'autos caratulados'
-            raw_pref = bloque[:mq.start()].strip()
-            if re.search(r'autos?\s+caratulad[oa]s?', raw_pref, flags=re.I):
-                # nos quedamos con lo que sigue a esa frase
-                prefix = re.split(r'autos?\s+caratulad[oa]s?', raw_pref, flags=re.I)[-1].strip()
-            else:
-                prefix = raw_pref
-            bloque = f'{prefix} {quoted}' if prefix else quoted
-        return f'{bloque.strip()} (SAC N° {nro})'
-
+        titulo, nro = m.groups()
+        return f'“{titulo.strip()}” (SAC N° {nro})'
 
     m = _PAT_CARAT_2.search(plano)
     if m:
@@ -243,32 +242,13 @@ def extraer_caratula(txt: str) -> str:
         nro  = mnum.group(1) if mnum else '…'
         return f'“{titulo}” (SAC N° {nro})'
 
+    # El encabezado suele estar en la primera página; me quedo con la 1ª coincidencia
     encabezados = _PAT_CARAT_3.findall(plano[:5000])
     if encabezados:
         nro, resto = encabezados[0]
         titulo = resto.split(' - ')[0].strip()
-
-        # --- Normalizo el bloque capturado ---------------------------
-        # 1) Espacio tras cada punto de la sigla P.S.A → p. s. a.
-        titulo = re.sub(r'\bP\.S\.A\b', 'p. s. a.', titulo, flags=re.I)
-
-        # 2) Pongo mayúsculas / minúsculas tipo título,
-        #    sin tocar la sigla recién armada
-        def _title_preservando_sigla(s: str) -> str:
-            tmp = []
-            for palabra in s.split():
-                if palabra.lower() in {'p.', 's.', 'a.'}:   # sigla
-                    tmp.append(palabra.lower())
-                else:
-                    tmp.append(palabra.capitalize())
-            return " ".join(tmp)
-
-        titulo = _title_preservando_sigla(titulo)
-
         return f'“{titulo}” (SAC N° {nro})'
-
-
-
+    return ""
 # ── TRIBUNAL ──────────────────────────────────────────────────────────
 # Lista de palabras clave válidas al inicio de la descripción
 _CLAVES_TRIB = (
@@ -313,12 +293,15 @@ def extraer_tribunal(txt: str) -> str:
 
 _FIRMA_FIN_PAT = re.compile(
     r'''
-        ^\s*(?:[\-\u2022*·]\s*)?                # posible viñeta
+        ^\s*(?:[\-\u2022*·]\s*)?   # posible viñeta o puntuación inicial
         (?:
-            (?:Texto\s+)?Firmad[oa]\s+digitalmente(?:\s+por:)? |
-            Firmad[oa] | Firma\s+digital | Texto\s+Firmado |
-            Fdo\.? | Expediente\s+SAC |
-            Fecha\s*:?\s*(?:\d{1,2}[./-]\d{1,2}[./-]\d{2,4}|\d{4}[./-]\d{1,2}[./-]\d{1,2})
+            (?:Texto\s+)?Firmad[oa]\s+digitalmente(?:\s+por:)?  # "Firmado digitalmente por:"
+          | Firmad[oa]                                 # Firmado / Firmada
+          | Firma\s+digital                            # Firma digital
+          | Texto\s+Firmado                            # Texto Firmado digitalmente
+          | Fdo\.?                                     # Fdo.:
+          | Fecha\s*:\s*\d{4}                         # Fecha: 2025‑08‑02
+          | Expediente\s+SAC                           # Expediente SAC …
         )
     ''', re.I | re.M | re.X)
 
@@ -358,31 +341,25 @@ def extraer_resuelvo(texto: str) -> str:
 
 
 _FIRMAS_REGEX = re.compile(r'''
+    # Cabecera opcional: "Firmado digitalmente por:" (con o sin "Texto")
     (?:^|\n)\s*
-    (?: (?:Texto\s+)?Firmad[oa]\s+digitalmente\s+por:\s* )?
-    (?P<nombre>[A-ZÁÉÍÓÚÑ][A-ZÁÉÍÓÚÑ\s.\-]+?)\s*
+    (?: (?:Texto\s+)?Firmad[oa]\s+digitalmente\s+por:\s* )?      
+
+    # Nombre (mayúsculas con espacios, puntos o guiones)
+    (?P<nombre>[A-ZÁÉÍÓÚÑ][A-ZÁÉÍÓÚÑ\s.\-]+?)\s*                
+
+    # Separador: coma o salto de línea
     (?: ,\s* | \n\s* )
-    (?P<cargo>[A-ZÁÉÍÓÚÑ/][^\n,]+)
-    (?: [,\s]* \n?\s* (?:CUIL|DNI|ID)\s* (?P<doc>[\d.\-]+) )?
-    (?: (?=[\s\S]*?Fecha\s*:?\s*(?:\d{1,2}[./-]\d{1,2}[./-]\d{2,4}|\d{4}[./-]\d{1,2}[./-]\d{1,2})) )?
+
+    # Cargo (toma todo hasta salto de línea o coma)
+    (?P<cargo>[A-ZÁÉÍÓÚÑ/][^\n,]+)                              
+
+    # Documento opcional en la misma línea o inmediata
+    (?: [,\s]* \n?\s* (?:CUIL|DNI|ID)\s* (?P<doc>[\d.\-]+) )?    
+
+    # Debe haber una línea "Fecha: aaaa.mm.dd" a ≤2 renglones
+    (?= (?:[^\n]*\n){0,2}\s*Fecha\s*:\s*\d{4}[./-]\d{2}[./-]\d{2} )
 ''', re.IGNORECASE | re.MULTILINE | re.UNICODE | re.VERBOSE)
-
-_FIRMAS_REGEX_FDO = re.compile(r'''
-    Fdo\.?\s*:\s*
-    (?P<nombre>[A-ZÁÉÍÓÚÑ][A-ZÁÉÍÓÚÑ\s.\-]+?)
-    (?:\s*,\s*(?P<cargo>[A-ZÁÉÍÓÚÑ/][^\n,]+))?
-''', re.IGNORECASE | re.MULTILINE | re.VERBOSE)
-
-_FIRMAS_BLOQUE = re.compile(
-    r'(?:^|\n)\s*(?:Texto\s+)?Firmad[oa]\s+digitalmente\s+por:?\s*'
-    r'(?P<nombre>[^\n]+?)\s*(?:\r?\n)+\s*(?P<cargo>[^\n]+)',
-    re.IGNORECASE
-)
-
-_FIRMAS_FDO = re.compile(
-    r'(?:^|\n)\s*Fdo\.?\s*:\s*(?P<nombre>[^\n,]+)\s*(?:,\s*(?P<cargo>[^\n]+))?',
-    re.IGNORECASE
-)
 
 
 # ── validaciones de campos ─────────────────────────────────────────────
@@ -390,8 +367,7 @@ _FIRMAS_FDO = re.compile(
 # Se admite un texto previo con o sin comillas y diferentes variantes de
 # "Expte."/"SAC"/"N°" al final.
 CARATULA_REGEX = QRegularExpression(
-    r'(?i)^\s*[^()]+\s*\((?:Expte\.?\s*)?(?:SAC|Expte\.?)\s*'
-    r'(?:N\s*[°ºo\.]*\s*)?[\d.]+\)$'
+    r'^["“][^"”]+(?:\(Expte\.\s*N°\s*\d+\))?["”](?:\s*\((?:SAC|Expte\.?)\s*N°\s*\d+\))?$'
 )
 # Tribunal: al menos una letra minúscula y empezar en mayúscula
 TRIBUNAL_REGEX = QRegularExpression(r'^(?=.*[a-záéíóúñ])[A-ZÁÉÍÓÚÑ].*$')
@@ -504,61 +480,21 @@ def normalizar_dni(txt: str) -> str:
     return re.sub(r"\D", "", str(txt))
 
 
-def _reordenar_nombre(n: str) -> str:
-    n = n.strip()
-    partes = n.split()
-    if not partes:
-        return n
-    i = 0
-    while i < len(partes) and partes[i].isupper():
-        i += 1
-    if 0 < i < len(partes):
-        apellidos = " ".join(partes[:i]).title()
-        nombres   = " ".join(partes[i:]).title()
-        return f"{nombres} {apellidos}".strip()
-    return capitalizar_frase(n)
-
-
-def _normalizar_cargo(c: str) -> str:
-    c = (c or "").strip()
-    c = c.replace("CAMARA", "Cámara").replace("CAMARA.", "Cámara.")
-    return capitalizar_frase(c)
 
 
 def extraer_firmantes(texto: str) -> list[dict]:
-    texto = limpiar_pies_de_pagina(texto)
-    start = max(0, int(len(texto) * 0.6))
-    cola = texto[start:]
-
-    vistos = set()
-    firmas: list[dict] = []
-
-    def _add(nombre, cargo="", doc=""):
-        nombre = (nombre or "").strip()
-        cargo  = (cargo or "").strip()
-        if not nombre:
-            return
-        nombre = _reordenar_nombre(nombre)
-        cargo  = _normalizar_cargo(cargo)
-        key = (nombre.upper(), cargo.upper())
-        if key in vistos:
-            return
-        vistos.add(key)
-        firmas.append({"nombre": nombre, "cargo": cargo, "doc": (doc or "").strip()})
-
-    for m in _FIRMAS_BLOQUE.finditer(cola):
-        _add(m.group("nombre"), m.group("cargo"))
-
-    for m in _FIRMAS_FDO.finditer(cola):
-        _add(m.group("nombre"), m.group("cargo") or "")
-
-    if not firmas:
-        for m in _FIRMAS_REGEX.finditer(cola):
-            _add(m.group("nombre"), m.group("cargo") or "", m.group("doc") or "")
-
+    """
+    Devuelve [{'nombre':…, 'cargo':…, 'doc':…}, …] con cada
+    firma hallada en el texto de la sentencia.
+    """
+    firmas = []
+    for m in _FIRMAS_REGEX.finditer(texto):
+        firmas.append({
+            "nombre": capitalizar_frase(m.group("nombre")).strip(),
+            "cargo" : capitalizar_frase(m.group("cargo")).strip(),
+            "doc"   : (m.group("doc") or "").strip(),
+        })
     return firmas
-
-
 
 # ── helpers varios ------------------------------------------------------
 def _as_str(value):
@@ -669,11 +605,20 @@ def procesar_sentencia(file_bytes: bytes, filename: str) -> Dict[str, Any]:
             {
                 "role": "system",
                 "content": (
-                    "Devolvé un JSON con la clave 'generales' "
-                    "(caratula, tribunal, sent_num, sent_fecha, "
-                    "resuelvo, firmantes) y la clave 'imputados' "
-                    "(lista).  Cada imputado debe traer "
-                    "`datos_personales` con nombre y dni al menos."
+                    "Devolvé un JSON con: "
+                    "generales (caratula, tribunal, sent_num, sent_fecha, resuelvo, firmantes) "
+                    "e imputados (lista).  Cada imputado debe traer un objeto "
+                    "datos_personales **con TODAS ESTAS CLAVES**:\n"
+                    "nombre, dni, nacionalidad, fecha_nacimiento, lugar_nacimiento, edad, "
+                    "estado_civil, domicilio, instruccion, ocupacion, padres, "
+                    "prontuario, seccion_prontuario.\n"
+                    "La **caratula** es la denominación de la causa, generalmente entre comillas "
+                    "y con “(SAC N° …)”, “(Expte. N° …)”, “(EE N° …)”, “(SAC …)”, "
+                    "“(Expte. …)”, “(EE …)”, etc..  Nunca debe contener la palabra "
+                    "Cámara, Juzgado ni Tribunal. "
+                    "“tribunal” es el órgano que dictó la sentencia, empieza con "
+                    "‘la Cámara’, ‘el Juzgado’, etc. "
+                    "Si un dato falta, dejá la clave vacía."
                 ),
             },
             {"role": "user", "content": texto[:120_000]},
@@ -685,22 +630,47 @@ def procesar_sentencia(file_bytes: bytes, filename: str) -> Dict[str, Any]:
         rsp = client.ChatCompletion.create(**kwargs)  # type: ignore
     datos = json.loads(rsp.choices[0].message.content)
 
-    # 3) Saneo rápido
-    g = datos.setdefault("generales", {})
-    g["resuelvo"] = extraer_resuelvo(texto) or g.get("resuelvo", "")
-    carat = extraer_caratula(texto)
-    if carat:
-        g["caratula"] = carat
-    else:
-        g.setdefault("caratula", "")
-    g.setdefault("tribunal", extraer_tribunal(texto))
+    # 3) Ajustes post-API
+    g = datos.get("generales", {})
+    g["resuelvo"] = extraer_resuelvo(texto)
+    g["resuelvo"] = limpiar_pies_de_pagina(
+        re.sub(r"\s*\n\s*", " ", g["resuelvo"])
+    ).strip()
+    g["resuelvo"] = re.sub(
+        r"(?i)\s*(?:texto\s+)?firmad[oa]\s+digitalmente.*",
+        "",
+        g["resuelvo"],
+    ).strip()
 
-    # usar SIEMPRE lo que detecta nuestro parser, si trajo algo
     firmas = extraer_firmantes(texto)
     if firmas:
-        g["firmantes"] = firmas
-    else:
-        g.setdefault("firmantes", [])
+        datos.setdefault("generales", {})["firmantes"] = firmas
+
+    carat_raw = g.get("caratula", "").strip()
+    trib_raw = g.get("tribunal", "").strip()
+
+    carat_ok = CARATULA_REGEX.match(carat_raw)
+    trib_ok = TRIBUNAL_REGEX.match(trib_raw)
+
+    if not carat_ok and (
+        "cámara" in carat_raw.lower() or "juzgado" in carat_raw.lower()
+    ):
+        carat_raw, trib_raw = "", carat_raw
+
+    if not trib_ok and trib_raw.lower().startswith("dr"):
+        trib_raw = ""
+
+    if not carat_ok:
+        nueva_carat = extraer_caratula(texto)
+        if nueva_carat:
+            g["caratula"] = nueva_carat
+
+    if not trib_ok:
+        nuevo_trib = extraer_tribunal(texto)
+        if nuevo_trib:
+            g["tribunal"] = nuevo_trib
+
+    datos["generales"] = g
 
 
     for imp in datos.get("imputados", []):


### PR DESCRIPTION
## Summary
- Copy original regex definitions from `ospro.py` for resuelvo, carátula, firmantes, and related helpers to match previous behavior
- Simplify firmante extraction to legacy approach and validate carátula format with the original pattern

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b3860a7bc83229db01cfc0fc7f6c7