### PR TITLE
Clamp imputados count to supported maximum

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from core import (
     DEPOSITOS,
     JUZ_NAVFYG,
     TRIBUNALES,
+    MAX_IMPUTADOS,
 )  # lógica de autocompletado y listas
 from helpers import dialog_link, strip_dialog_links, create_clipboard_html
 
@@ -481,8 +482,9 @@ with st.sidebar:
     itim_fecha = col_it[1].text_input("Fecha", key="itim_fecha")
 
     # Nº de imputados dinámico
+    st.session_state.n_imputados = min(st.session_state.n_imputados, MAX_IMPUTADOS)
     n = st.number_input(
-        "Número de imputados", 1, 20, st.session_state.n_imputados,
+        "Número de imputados", 1, MAX_IMPUTADOS, st.session_state.n_imputados,
         key="n_imp", on_change=st.rerun,
     )
     st.session_state.n_imputados = n

--- a/core.py
+++ b/core.py
@@ -132,6 +132,10 @@ TRIBUNALES = [
 ]
 
 
+# Máximo de imputados soportados por la interfaz
+MAX_IMPUTADOS = 20
+
+
 def _get_openai_client():
     """Return an OpenAI client compatible with v0 and v1 APIs."""
     api_key = os.environ.get("OPENAI_API_KEY", _cfg.get("api_key", ""))
@@ -816,7 +820,8 @@ def autocompletar(file_bytes: bytes, filename: str) -> None:
 
 
     # ----- IMPUTADOS -----
-    imps = datos.get("imputados", [])
+    # limitamos al máximo soportado por la UI
+    imps = datos.get("imputados", [])[:MAX_IMPUTADOS]
     st.session_state.n_imputados = max(1, len(imps))
 
     for i, imp in enumerate(imps):
@@ -846,6 +851,7 @@ __all__ = [
     "DEPOSITOS",
     "JUZ_NAVFYG",
     "TRIBUNALES",
+    "MAX_IMPUTADOS",
 ]
 
 


### PR DESCRIPTION
## Summary
- prevent crashes when imported data contains more than 20 imputados by capping the count
- expose a shared MAX_IMPUTADOS constant and use it across the app and core logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b45c2ff8c83228177396cfd3074c4