### PR TITLE
perf: defer AI personal data fallback

### DIFF
--- a/core.py
+++ b/core.py
@@ -443,45 +443,120 @@ def _recortar_bloque_un_persona(b: str) -> str:
         s = s[:dnis[1].start()]
     return s.strip()
 
+
+def _extraer_datos_personales_ia(texto: str) -> dict:
+    """Intenta extraer datos personales usando un modelo de lenguaje.
+
+    Devuelve un ``dict`` con las claves solicitadas.  Si falla o no hay
+    credenciales de OpenAI configuradas, retorna un ``dict`` vacío.
+    """
+    try:
+        client = _get_openai_client()
+    except Exception:
+        return {}
+
+    kwargs = dict(
+        model="gpt-4o-mini",
+        temperature=0,
+        response_format={"type": "json_object"},
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Extraé un JSON con las claves: nombre, dni, ocupacion, "
+                    "padres, domicilio, alias, fecha_nacimiento y nacionalidad. "
+                    "Si algún dato falta, devolvé la clave vacía."
+                ),
+            },
+            {"role": "user", "content": texto[:4000]},
+        ],
+    )
+    try:
+        if hasattr(client, "chat"):
+            rsp = client.chat.completions.create(**kwargs)  # type: ignore
+        else:  # pragma: no cover - API v0
+            rsp = client.ChatCompletion.create(**kwargs)  # type: ignore
+        return json.loads(rsp.choices[0].message.content)
+    except Exception:
+        return {}
+
 def extraer_datos_personales(texto: str) -> dict:
-    t = re.sub(r'\s+', ' ', texto)
+    t = re.sub(r"\s+", " ", texto)
     dp: dict[str, str | list] = {}
 
-    # Nombre: prefiero el que está al INICIO del bloque; si no, el genérico
+    # 1) Extraer todo lo posible con regex (rápido)
     m = NOMBRE_INICIO_RE.search(t) or NOMBRE_RE.search(t)
     if m:
-        dp["nombre"] = capitalizar_frase(m.group(1).strip())
+        dp.setdefault("nombre", capitalizar_frase(m.group(1).strip()))
 
-    # DNI (robusto) — ¡aquí va el fix!
-    m_dni_txt = DNI_TXT_RE.search(t)    # ... D.N.I. N° 12.345.678 ...
-    m_dni_num = DNI_REGEX.search(t)     # ... 12345678 o 12.345.678 ...
+    m_dni_txt = DNI_TXT_RE.search(t)
+    m_dni_num = DNI_REGEX.search(t)
     first_dni = m_dni_txt or m_dni_num
     if m_dni_txt:
-        dp["dni"] = normalizar_dni(m_dni_txt.group(1))   # tiene grupo (1)
+        dp.setdefault("dni", normalizar_dni(m_dni_txt.group(1)))
     elif m_dni_num:
-        dp["dni"] = normalizar_dni(m_dni_num.group(0))   # solo group(0)
+        dp.setdefault("dni", normalizar_dni(m_dni_num.group(0)))
 
-    # Alias: SOLO busco antes del primer DNI para que no “herede” de otro imputado
-    alias_scope = t[:first_dni.start()] if first_dni else t
+    alias_scope = t[: first_dni.start()] if first_dni else t
     m_alias = ALIAS_RE.search(alias_scope)
     if m_alias:
-        dp["alias"] = m_alias.group(1).strip()
+        dp.setdefault("alias", m_alias.group(1).strip())
 
-    # Resto igual:
-    if (m := EDAD_RE.search(t)):    dp["edad"]  = m.group(1)
-    if (m := NAC_RE.search(t)):     dp["nacionalidad"] = m.group(1).strip()
-    if (m := ECIVIL_RE.search(t)):  dp["estado_civil"] = m.group(1).strip()
-    if (m := OCUP_RE.search(t)):    dp["ocupacion"]    = m.group(1).strip()
-    if (m := INSTR_RE.search(t)):   dp["instruccion"]  = m.group(1).strip()
-    if (m := DOM_RE.search(t)):     dp["domicilio"]    = m.group(1).strip()
-    if (m := FNAC_RE.search(t)):    dp["fecha_nacimiento"] = m.group(1).strip()
-    if (m := LNAC_RE.search(t)):    dp["lugar_nacimiento"] = m.group(1).strip()
+    if (m := EDAD_RE.search(t)):
+        dp.setdefault("edad", m.group(1))
+    if (m := NAC_RE.search(t)):
+        dp.setdefault("nacionalidad", m.group(1).strip())
+    if (m := ECIVIL_RE.search(t)):
+        dp.setdefault("estado_civil", m.group(1).strip())
+    if (m := OCUP_RE.search(t)):
+        dp.setdefault("ocupacion", m.group(1).strip())
+    if (m := INSTR_RE.search(t)):
+        dp.setdefault("instruccion", m.group(1).strip())
+    if (m := DOM_RE.search(t)):
+        dp.setdefault("domicilio", m.group(1).strip())
+    if (m := FNAC_RE.search(t)):
+        dp.setdefault("fecha_nacimiento", m.group(1).strip())
+    if (m := LNAC_RE.search(t)):
+        dp.setdefault("lugar_nacimiento", m.group(1).strip())
     if (m := PADRES_RE.search(t)):
         padres = [m.group(1).strip()]
-        if m.group(2): padres.append(m.group(2).strip())
-        dp["padres"] = padres
+        if m.group(2):
+            padres.append(m.group(2).strip())
+        dp.setdefault("padres", padres)
     if (m := PRIO_RE.search(t)):
-        dp["prio"] = m.group(1).strip()
+        dp.setdefault("prio", m.group(1).strip())
+
+    # 2) Fallback lento con IA sólo si faltan campos
+    faltantes = [
+        k
+        for k in (
+            "nombre",
+            "dni",
+            "ocupacion",
+            "padres",
+            "domicilio",
+            "alias",
+            "fecha_nacimiento",
+            "nacionalidad",
+        )
+        if not dp.get(k)
+    ]
+    if faltantes:
+        dp_ia = _extraer_datos_personales_ia(t)
+        if dp_ia.get("dni"):
+            dp_ia["dni"] = normalizar_dni(dp_ia.get("dni"))
+        if isinstance(dp_ia.get("padres"), str):
+            padres = [
+                p.strip()
+                for p in re.split(r"\s+y\s+|,", dp_ia["padres"])
+                if p.strip()
+            ]
+            dp_ia["padres"] = padres
+        if dp_ia.get("nombre"):
+            dp_ia["nombre"] = capitalizar_frase(dp_ia["nombre"])
+        for k in faltantes:
+            if dp_ia.get(k):
+                dp[k] = dp_ia[k]
 
     return dp
 


### PR DESCRIPTION
## Summary
- run regex extraction first for personal data
- only invoke OpenAI when required fields remain missing to avoid slow autocompletion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b4baa84e48322aeacb7ec56fa3407