### PR TITLE
Improve defendant name extraction before DNI

### DIFF
--- a/core.py
+++ b/core.py
@@ -399,6 +399,11 @@ NOMBRE_INICIO_RE = re.compile(
     r'^\s*([A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑ.\-]+(?:\s+[A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑ.\-]+){1,3})\s*,',
     re.M
 )
+# Fallback: nombre justo antes de "DNI" (sin edad requerida)
+NOMBRE_DNI_RE = re.compile(
+    r'^\s*(?:imputad[oa]:?\s*)?([A-ZÁÉÍÓÚÑ][^,\n]+?)\s*(?:,\s*)?(?:D\.?\s*N\.?\s*I\.?|DNI)',
+    re.I | re.M,
+)
 
 # ── NUEVO: helpers de segmentación ─────────────────────────
 MULTI_PERSONA_PAT = re.compile(r'(D\.?\s*N\.?\s*I\.?|Prontuario)', re.I)
@@ -467,6 +472,8 @@ def extraer_datos_personales(texto: str) -> dict:
     # Nombre: prefiero el que está al INICIO del bloque; si no, el genérico
     m = NOMBRE_INICIO_RE.search(t) or NOMBRE_RE.search(t)
     if m:
+        dp["nombre"] = capitalizar_frase(m.group(1).strip())
+    elif m is None and (m := NOMBRE_DNI_RE.search(t)):
         dp["nombre"] = capitalizar_frase(m.group(1).strip())
 
     # DNI (robusto)

--- a/tests/test_datos_personales_nombre_dni.py
+++ b/tests/test_datos_personales_nombre_dni.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stubs mínimos para módulos opcionales que usa core
+sys.modules.setdefault("streamlit", types.SimpleNamespace(session_state={}))
+sys.modules.setdefault("docx2txt", types.ModuleType("docx2txt"))
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+pdf_high = types.ModuleType("pdfminer.high_level")
+pdf_high.extract_text = lambda *a, **k: ""
+sys.modules.setdefault("pdfminer", types.ModuleType("pdfminer"))
+sys.modules.setdefault("pdfminer.high_level", pdf_high)
+
+import core
+
+def test_extrae_nombre_antes_de_dni_sin_edad():
+    texto = "Imputado: Juan de la Cruz Pérez, DNI 12.345.678, argentino, soltero"
+    dp = core.extraer_datos_personales(texto)
+    assert dp["nombre"] == "Juan de la Cruz Pérez"
+    assert dp["dni"] == "12345678"


### PR DESCRIPTION
## Summary
- handle names directly before DNI using new regex fallback
- add regression test for names without age information

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c75ea9c7c8322838c80223ec11bfd