### PR TITLE
Handle DNI formats and multiple defendants

### DIFF
--- a/core.py
+++ b/core.py
@@ -393,15 +393,20 @@ FNAC_RE = re.compile(r'(?:Nacid[oa]\s+el\s+|el\s*d[íi]a\s*)(\d{1,2}/\d{1,2}/\d{
 LNAC_RE    = re.compile(r'Nacid[oa]\s+el\s+\d{1,2}/\d{1,2}/\d{2,4},?\s+en\s+([^.,\n]+)', re.I)
 PADRES_RE  = re.compile(r'hij[oa]\s+de\s+([^.,\n]+?)(?:\s+y\s+de\s+([^.,\n]+))?(?:[,.;]|\s$)', re.I)
 PRIO_RE    = re.compile(r'(?:Prontuario|Prio\.?|Pront\.?)\s*[:\-]?\s*([^\n.;]+)', re.I)
-DNI_TXT_RE = re.compile(r'(?:D\.?\s*N\.?\s*I\.?|DNI)\s*:?\s*([\d.]+)', re.I)
+# Permite variantes como "DNI n.º 12.345.678" o "DNI N°12345678"
+DNI_TXT_RE = re.compile(
+    r'(?:D\.?\s*N\.?\s*I\.?|DNI)\s*'
+    r'(?:n(?:ro)?\.?\s*(?:[°º])?\s*)?[:\-]?\s*([\d.]+)',
+    re.I,
+)
 NOMBRE_RE  = re.compile(r'([A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑ\s.\-]+?),\s*de\s*\d{1,3}\s*años.*?D\.?N\.?I\.?:?\s*[\d.]+', re.I | re.S)
 NOMBRE_INICIO_RE = re.compile(
-    r'^\s*([A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑ.\-]+(?:\s+[A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑ.\-]+){1,3})\s*,',
+    r'^\s*(?:[YyEe]\s+)?([A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑáéíóúñüÜ.\-]+(?:\s+[A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑáéíóúñüÜ.\-]+){1,3})\s*,',
     re.M
 )
 # Fallback: nombre justo antes de "DNI" (sin edad requerida)
 NOMBRE_DNI_RE = re.compile(
-    r'^\s*(?:imputad[oa]:?\s*)?([A-ZÁÉÍÓÚÑ][^,\n]+?)\s*(?:,\s*)?(?:D\.?\s*N\.?\s*I\.?|DNI)',
+    r'^\s*(?:imputad[oa]:?\s*)?(?:[YyEe]\s+)?([A-ZÁÉÍÓÚÑ][^,\n]+?)\s*(?:,\s*)?(?:D\.?\s*N\.?\s*I\.?|DNI)',
     re.I | re.M,
 )
 
@@ -421,7 +426,7 @@ def segmentar_imputados(texto: str) -> list[str]:
 
     # Intento segmentar por "Nombre, ..." que arranca una ficha
     NAME_START = re.compile(
-        r'(?<!\w)([A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑ.\-]+(?:\s+[A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑ.\-]+){1,3})\s*,\s*'
+        r'(?<!\w)(?:[YyEe]\s+)?([A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑáéíóúñüÜ.\-]+(?:\s+[A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÑáéíóúñüÜ.\-]+){1,3})\s*,\s*'
         r'(?:(?i:de\s*\d{1,3}\s*años|D\.?\s*N\.?\s*I\.?|nacionalidad))'
     )
     hits = list(NAME_START.finditer(plano))
@@ -429,11 +434,11 @@ def segmentar_imputados(texto: str) -> list[str]:
     bloques: list[str] = []
     if hits:
         for i, m in enumerate(hits):
-            start = m.start()
+            start = m.start(1)
             # Si antes del nombre hay un "Prontuario" o "Prio." cercano, incluyo desde allí
             if (m_prio := re.search(r"(?:Prontuario|Prio\.?)[^\n.]*\.\s*$", plano[:start], re.I)):
                 start = m_prio.start()
-            end = hits[i+1].start() if i + 1 < len(hits) else len(plano)
+            end = hits[i+1].start(1) if i + 1 < len(hits) else len(plano)
             bloques.append(_recortar_bloque_un_persona(plano[start:end]))
         return bloques
 

--- a/tests/test_segmentar_multiples_imputados.py
+++ b/tests/test_segmentar_multiples_imputados.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stubs for optional dependencies used by core.py
+sys.modules.setdefault("docx2txt", types.ModuleType("docx2txt"))
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+st = types.ModuleType("streamlit")
+st.session_state = {}
+sys.modules.setdefault("streamlit", st)
+pdfminer = types.ModuleType("pdfminer")
+high = types.ModuleType("pdfminer.high_level")
+high.extract_text = lambda *a, **k: ""
+pdfminer.high_level = high
+sys.modules.setdefault("pdfminer", pdfminer)
+sys.modules.setdefault("pdfminer.high_level", high)
+
+import core
+
+def test_segmenta_dos_imputados_y_extrae_dni():
+    texto = (
+        "Saúl Maximiliano Agüero, de 20 años de edad, DNI n.° 52.053.434, domiciliado en calle Bilbao n.° 2832. "
+        "Prio. Policial AG AG- 1319566 AG- 1381005. "
+        "E Imanol Andrés Urán, de 25 años de edad, DNI n.° 42.440.252, domiciliado en calle Manuel Astrada n.° 1488."
+    )
+    bloques = core.segmentar_imputados(texto)
+    assert len(bloques) == 2
+    dp1 = core.extraer_datos_personales(bloques[0])
+    dp2 = core.extraer_datos_personales(bloques[1])
+    assert dp1["nombre"] == "Saúl Maximiliano Agüero"
+    assert dp1["dni"] == "52053434"
+    assert dp2["nombre"] == "Imanol Andrés Urán"
+    assert dp2["dni"] == "42440252"


### PR DESCRIPTION
## Summary
- Parse DNI lines with number markers like `DNI n.º 12.345.678`
- Support leading conjunctions and accented characters when segmenting defendants
- Cover multi-defendant extraction in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c7d8f7db88322bb0faa3ae4731de4