### PR TITLE
Fix httpx proxy parameter

### DIFF
--- a/core.py
+++ b/core.py
@@ -198,7 +198,7 @@ def _get_openai_client():
     # httpx.Client propio
     import httpx
     http_client = httpx.Client(
-        proxies=proxy or None,
+        proxy=proxy or None,
         timeout=httpx.Timeout(30.0),
         limits=httpx.Limits(max_keepalive_connections=10, max_connections=20),
         follow_redirects=True,


### PR DESCRIPTION
## Summary
- use correct `proxy` parameter when creating `httpx.Client`

## Testing
- `pytest` *(fails: autocompletar firmantes, datos personales prio)*

------
https://chatgpt.com/codex/tasks/task_b_68a11ce595408322bb3d4a534734d3ec