### PR TITLE
Remove hardcoded OpenAI key references

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,3 +1,2 @@
 {
-  "api_key": "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"
 }

--- a/core.py
+++ b/core.py
@@ -140,7 +140,7 @@ MAX_IMPUTADOS = 20
 CONFIG_FILE = "config.json"
 
 # ⚠️ NO RECOMENDADO: solo como último recurso y NUNCA commitear.
-HARDCODED_OPENAI_KEY = "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"  # ← si insistís, pegá aquí tu clave (temporalmente)
+HARDCODED_OPENAI_KEY = ""  # ← si insistís, pegá aquí tu clave (temporalmente)
 
 def _get_openai_client():
     """


### PR DESCRIPTION
## Summary
- Clear OpenAI API key from config.json
- Drop hardcoded OpenAI key constant in core module

## Testing
- `pytest -q` *(fails: tests/test_autocompletar_firmantes.py::test_autocompletar_converts_firmantes_to_string, tests/test_autocompletar_firmantes.py::test_autocompletar_handles_dict_firmantes, tests/test_datos_personales_prio.py::test_extrae_nombre_y_prontuario_cuando_prio_primero)*

------
https://chatgpt.com/codex/tasks/task_b_68a126c1ed3c832299e484fbed6cf0fb