### PR TITLE
Fix carátula entry normalization and enhance parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -320,6 +320,8 @@ if isinstance(edit_event, dict):
     k, v = edit_event.get("key"), edit_event.get("value")
     if isinstance(k, str) and isinstance(v, str):
         st.session_state[k] = v
+        if k == "carat":
+            _normalizar_caratula()
         # No hacer rerun aquí, los cambios se reflejarán automáticamente
 
 


### PR DESCRIPTION
## Summary
- Normalize carátula text when edited inline
- Format firmantes consistently and expose as `sfirmaza`
- Improve segmentation and name parsing for imputados

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a452a3d15c8322b8170831712b4124